### PR TITLE
fix(parser): accept explicit type instantiation on calls

### DIFF
--- a/crates/larvae/src/syntax/parser/expr.rs
+++ b/crates/larvae/src/syntax/parser/expr.rs
@@ -189,11 +189,44 @@ impl<'a> Parser<'a> {
                     self.bump();
 
                     let method = self.expect_name()?;
+
+                    // a method call takes type arguments too, `obj:m<<T>>()`
+                    if self.at("<") && self.text_at(1) == "<" {
+                        self.angle_span()?;
+                    }
+
                     let args = self.call_args()?;
 
                     e = Expr::Call {
                         func: Box::new(e),
                         method: Some(method),
+                        args,
+                        span: TokSpan::new(start, self.pos),
+                    };
+                }
+
+                /*
+                Explicit type instantiation, `f<<T>>()`, which Luau calls a
+                turbofish. This is the only place two `<` sit next to each
+                other: no expression starts with `<`, and Luau has no shift
+                operator, so there is nothing to disambiguate against.
+
+                The argument is a type or a type pack, so `<<number>>`,
+                `<<(number, string)>>`, `<<()>>` and `<<...number>>` are all
+                legal. `angle_span` already depth counts brackets, which is why
+                the nested pair needs no special case.
+
+                A turbofish only ever precedes a call, so `call_args` is
+                required rather than optional, and reports it when missing.
+                */
+                "<" if self.text_at(1) == "<" => {
+                    self.angle_span()?;
+
+                    let args = self.call_args()?;
+
+                    e = Expr::Call {
+                        func: Box::new(e),
+                        method: None,
                         args,
                         span: TokSpan::new(start, self.pos),
                     };

--- a/crates/larvae/tests/parser.rs
+++ b/crates/larvae/tests/parser.rs
@@ -44,6 +44,11 @@ fn rejects(src: &str) {
 }
 
 const CORPUS: &[&str] = &[
+    // --- explicit type instantiation, so the sweeps mutate and truncate it ---
+    "local a = charm.atom<<number>>()\n",
+    "local a = charm.atom<<(number, string)>>()\n",
+    "local a = obj:method<<...number>>()\n",
+    "local a = f<<Map<string, number>>>()\n",
     // --- basics ---
     "",
     "\n\n",
@@ -194,6 +199,58 @@ end
 return t
 "##,
 ];
+
+/*
+Explicit type instantiation, Luau's turbofish. The argument is a type or a type
+pack, so all of these are legal, and the round trip matters as much as the parse
+because a swallowed span would silently drop the type arguments from the output.
+*/
+#[test]
+fn turbofish_type_arguments() {
+    round_trip("local a = charm.atom<<number>>()\n");
+    round_trip("local a = charm.atom<<(number, string)>>()\n");
+    round_trip("local a = charm.atom<<()>>()\n");
+    round_trip("local a = charm.atom<<...number>>()\n");
+    round_trip("local a = charm.atom<<{ x: number }>>()\n");
+    round_trip("local a = f<<number>>()\n");
+
+    // nested generics, which is why the bracket counting has to be by depth
+    round_trip("local a = charm.atom<<Map<string, number>>>()\n");
+    round_trip("local a = f<<A<B<C>>>>()\n");
+
+    // a method call takes them too
+    round_trip("local a = obj:method<<number>>()\n");
+    round_trip("local a = obj:method<<(number, string)>>()\n");
+
+    // and the other two call argument forms
+    round_trip("local a = f<<number>>{ 1, 2 }\n");
+    round_trip("local a = f<<string>>\"lit\"\n");
+
+    // chained, so the suffix loop keeps going afterwards
+    round_trip("local a = f<<number>>().field\n");
+    round_trip("local a = f<<number>>()<<string>>()\n");
+}
+
+/// A single `<` is still a comparison and must not be read as a turbofish
+#[test]
+fn comparisons_are_not_turbofish() {
+    round_trip("local a = b < c\n");
+    round_trip("local a = b < c and c < d\n");
+    round_trip("local a = f(b < c)\n");
+    round_trip("local a = t[b < c]\n");
+    round_trip("if a < b then end\n");
+
+    // a generic call in type position, unrelated to the expression form
+    round_trip("local a: Map<string, number> = x\n");
+}
+
+/// A turbofish only ever precedes a call, so a bare one is a real error
+#[test]
+fn a_turbofish_without_a_call_is_rejected() {
+    rejects("local a = f<<number>>\n");
+    rejects("local a = f<<number>> + 1\n");
+    rejects("local a = f<<number\n");
+}
 
 #[test]
 fn corpus_round_trips() {


### PR DESCRIPTION
`charm.atom<<number>>()` was reported as a syntax error:

```
error: syntax error, expected a name, found `<`
    at src/a.luau:2:22
```

Luau's turbofish passes type arguments to a call, and the argument can be a type
**or a type pack**, so all of these are legal:

```luau
charm.atom<<number>>()
charm.atom<<(number, string)>>()
charm.atom<<()>>()
charm.atom<<...number>>()
charm.atom<<Map<string, number>>>()
obj:method<<number>>()
```

## The cause

The suffix loop had no case for it, so the two `<` fell through to the binary
operator parser, which tried to read an expression starting with `<`.

## The fix

One case in `suffixed_expr`, plus the same on method calls.

**No lexer change was needed.** `<<` is not in the operator table, so it arrives
as two `<` tokens, and `angle_span` already counts bracket depth. That is why
nested generics like `<<Map<string, number>>>` need no special handling.

**Two `<` in a row are unambiguous.** No expression starts with `<`, and Luau has
no shift operator, so there is nothing to disambiguate against. A single `<` is
still a comparison, and `comparisons_are_not_turbofish` covers it.

A turbofish only ever precedes a call, so call arguments are required rather than
optional. `f<<number>>` on its own is still an error.

## Tests

Round trip rather than parse only, because a swallowed span would drop the type
arguments from the output while still parsing:

- `turbofish_type_arguments`, 14 forms including nesting, method calls, table and
  string call arguments, and chaining
- `comparisons_are_not_turbofish`, the regression guard
- `a_turbofish_without_a_call_is_rejected`

Four entries added to `CORPUS` so the mutation and truncation sweeps exercise
them too.

452 tests, fmt and clippy clean. Verified end to end: `larvae check` is clean on
the reported snippet and `larvae process` rewrites the require while leaving the
turbofish byte for byte intact.