### PR TITLE
feat: port the finish-m3 work onto the worm era

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,23 @@ jobs:
         shell: pwsh
         run: Compress-Archive -Path "target\${{ matrix.target }}\release\larvae.exe" -DestinationPath "${{ matrix.asset }}.zip"
 
+      - name: Report the size
+        if: runner.os != 'Windows'
+        run: |
+          set -euo pipefail
+          BIN=$(find "target/${{ matrix.target }}/release" -maxdepth 1 -name larvae -type f)
+          {
+            echo "**${{ matrix.asset }}**: binary $(numfmt --to=iec $(stat -c%s "$BIN" 2>/dev/null || stat -f%z "$BIN")), zip $(numfmt --to=iec $(stat -c%s "${{ matrix.asset }}.zip" 2>/dev/null || stat -f%z "${{ matrix.asset }}.zip"))"
+          } >> "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Report the size
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $bin = (Get-Item "target\${{ matrix.target }}\release\larvae.exe").Length
+          $zip = (Get-Item "${{ matrix.asset }}.zip").Length
+          "**${{ matrix.asset }}**: binary $([math]::Round($bin/1MB,1)) MB, zip $([math]::Round($zip/1MB,1)) MB" >> $env:GITHUB_STEP_SUMMARY
+
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset }}
@@ -143,6 +160,38 @@ jobs:
 
           gh release upload "$TAG" dist/*.zip --clobber
 
+      # One table for every platform: the zip a user downloads, and the
+      # binary inside it. The table lands in the run summary and in the
+      # release notes, and a re-run replaces it instead of appending twice.
+      - name: The size of every binary
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.verify.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "### Binaries"
+            echo ""
+            echo "| asset | binary | zip |"
+            echo "|---|---:|---:|"
+            for z in dist/*.zip; do
+              NAME=$(basename "$z" .zip)
+              ZIP=$(numfmt --to=iec "$(stat -c%s "$z")")
+              RAW=$(unzip -l "$z" | tail -1 | awk '{print $1}')
+              BIN=$(numfmt --to=iec "$RAW")
+              echo "| $NAME | $BIN | $ZIP |"
+            done
+          } > sizes.md
+
+          cat sizes.md >> "$GITHUB_STEP_SUMMARY"
+
+          gh release view "$TAG" --json body -q .body | awk '/^### Binaries$/{exit} {print}' > notes.md
+          printf '\n' >> notes.md
+          cat sizes.md >> notes.md
+          gh release edit "$TAG" --notes-file notes.md
+
   crates:
     name: Publish to crates.io
     needs: [verify, release]
@@ -153,6 +202,25 @@ jobs:
           ref: ${{ needs.verify.outputs.tag }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo publish -p larvae --locked --token "$CARGO_REGISTRY_TOKEN"
+      # The verify job already proved the tag equals the Cargo.toml version,
+      # so what publishes here is always the version the tag names. A crate
+      # whose version is already on crates.io is skipped, so a re-run of a
+      # partly failed release publishes only what is missing. larvae-worm
+      # goes first: a worm author needs the guest crate at the version the
+      # host speaks.
+      - name: Publish what this version is missing
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_SECRET }}
+          TAG: ${{ needs.verify.outputs.tag }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+
+          for CRATE in larvae-worm larvae; do
+            if curl -fsS -A "larvae-release" "https://crates.io/api/v1/crates/${CRATE}/${VERSION}" >/dev/null 2>&1; then
+              echo "${CRATE} ${VERSION} is already on crates.io, skipping"
+              continue
+            fi
+
+            cargo publish -p "$CRATE" --locked --token "$CARGO_REGISTRY_TOKEN"
+          done

--- a/crates/larvae/larvae.schema.json
+++ b/crates/larvae/larvae.schema.json
@@ -70,6 +70,9 @@
           "lint": {
             "$ref": "#/$defs/lint"
           },
+          "bundle": {
+            "$ref": "#/$defs/bundle"
+          },
           "minify": {
             "$ref": "#/$defs/minify"
           }
@@ -1312,48 +1315,22 @@
       }
     },
     "bundle": {
-      "description": "Single-file bundling with deterministic module-init ordering. Present = enabled. (M3)",
+      "description": "Single-file output for `larvae bundle`. Each module initialises on first require, so the bundle keeps the demand order of the unbundled project.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "entry"
-      ],
       "properties": {
         "entry": {
           "type": "string",
-          "description": "Entry-point module."
+          "description": "The module the bundle starts from, relative to the project root. `--entry` overrides it."
         },
         "output": {
-          "type": "string"
-        },
-        "excludes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Requires left as-is (runtime-provided), e.g. \"@lune/**\"."
-        },
-        "modules_identifier": {
           "type": "string",
-          "default": "__LARVAE_MODULES"
+          "description": "Where the single file goes, relative to the project root. Default: bundle.luau."
         },
         "tree_shake": {
           "type": "boolean",
           "default": true,
-          "description": "Drop modules unreachable from the entry point."
-        },
-        "loaders": {
-          "type": "object",
-          "description": "Data files required as modules are converted to Lua tables (glob -> loader).",
-          "additionalProperties": {
-            "enum": [
-              "json",
-              "toml",
-              "yaml",
-              "text",
-              "skip"
-            ]
-          }
+          "description": "Drop the modules that the entry cannot reach. Turn off to keep modules that only a dynamic require reaches."
         }
       }
     },

--- a/crates/larvae/larvae.schema.json
+++ b/crates/larvae/larvae.schema.json
@@ -719,6 +719,15 @@
             }
           }
         },
+        "require_binding": {
+          "enum": [
+            "preserve",
+            "const",
+            "local"
+          ],
+          "default": "preserve",
+          "description": "Selects which keyword binds a required module. Luau enforces \"const\", so a name that the file reassigns keeps \"local\" and does not become a syntax error. \"preserve\" keeps each declaration as written."
+        },
         "magic_trailing_comma": {
           "type": "boolean",
           "default": true,
@@ -1031,6 +1040,14 @@
             "deny"
           ],
           "description": "A UDim2.new that fromScale or fromOffset says more clearly. Default: warn."
+        },
+        "non_const_require": {
+          "enum": [
+            "allow",
+            "warn",
+            "deny"
+          ],
+          "description": "A required module bound with local, where const says it never changes. The lint skips a name that the file reassigns, because const would then be a syntax error. Default: allow."
         },
         "unreachable_code": {
           "enum": [
@@ -1363,40 +1380,40 @@
       }
     },
     "check": {
-      "description": "CI-gate diagnostics for `larvae check`. (M3)",
+      "description": "Whole-project analyses that `larvae check` runs over the require graph. Each check is a level, like [lint.rules], so the project decides what fails CI.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "disallow_cycles": {
-          "type": "boolean",
-          "default": true,
-          "description": "Require cycles fail the check."
+        "cycles": {
+          "enum": [
+            "allow",
+            "warn",
+            "deny"
+          ],
+          "description": "Modules that require each other, directly or through a chain. The report names the whole cycle. Default: warn."
         },
-        "disallow_unused_modules": {
-          "type": "boolean",
-          "default": false,
-          "description": "Files unreachable from any entry point."
+        "unused_modules": {
+          "enum": [
+            "allow",
+            "warn",
+            "deny"
+          ],
+          "description": "Modules that nothing requires. A Script or LocalScript is never reported, because Roblox runs those. Default: allow."
         },
-        "entry_points": {
+        "early_require": {
+          "enum": [
+            "allow",
+            "warn",
+            "deny"
+          ],
+          "description": "Client scripts that require through an indexing style that does not wait for replication. Only the roblox-instance target. Default: warn."
+        },
+        "entries": {
           "type": "array",
           "items": {
             "type": "string"
-          }
-        },
-        "realm_analysis": {
-          "type": "boolean",
-          "default": true,
-          "description": "Error when client-reachable code requires server-only containers."
-        },
-        "early_require_diagnostics": {
-          "type": "boolean",
-          "default": true,
-          "description": "Flag string requires reachable from early client entry points (no wait semantics)."
-        },
-        "native_expressible": {
-          "type": "boolean",
-          "default": true,
-          "description": "Flag emitted requires that can't be native string form."
+          },
+          "description": "Extra entry points, as paths relative to the project root. A module in this list is never reported as unused."
         }
       }
     }

--- a/crates/larvae/src/bundle/emit.rs
+++ b/crates/larvae/src/bundle/emit.rs
@@ -1,0 +1,355 @@
+/*!
+The single file, and the runtime that makes it behave like the project did.
+
+## The shape
+
+Every module becomes a thunk in a registry, and requires between them become
+calls into a loader:
+
+```lua
+local __larvae = {}
+local __result = {}
+local __loading = {}
+
+local function __require(id) ... end
+
+__larvae["src/shared/util"] = function()
+    -- the module's own source, requires rewritten
+end
+
+return __require("src/main")
+```
+
+## Why lazy thunks and not an initialisation order
+
+A bundler can emit modules in dependency order and run them top to bottom.
+Then a cycle has no valid order, and the emitter must invent one. Thunks
+remove the question: nothing runs until something requires it, so
+**initialisation order is demand order**, which is exactly the order the
+unbundled project had. A bundle therefore cannot move the side effects of a
+module, and that property makes bundling safe to turn on for an existing
+game.
+
+The topological sort still runs, for a different reason: it decides the
+order the thunks are *written* to the file, so the bundle is byte identical
+across runs. Correctness does not depend on it.
+
+## Cycles
+
+A cyclic require that happens at load time errors, naming the module. This
+matches unbundled Roblox, which raises "Requested module was required
+recursively". And an error here is better than a half built module: a nil
+field read three files away is much harder to trace back than an error at
+the require that caused it.
+
+The pattern that looks cyclic and is not, a require inside a function that
+runs later, keeps working: by the time it runs, the other module has
+finished. That is the common shape in Roblox code, and the reason `check`
+reports cycles as a warning and not an error.
+*/
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// One module, ready to be written into the bundle
+pub struct Module {
+    /// What `__require` is called with, stable and readable in an error
+    pub id: String,
+    /// The module's source, with its requires already rewritten
+    pub source: String,
+}
+
+/*
+The loader.
+
+Written out and not generated, because it is the one part of the output a
+human reads when something goes wrong, and it is the same every time.
+
+`__result` holds a one field table and not the value itself, so a module
+that legitimately returns nil is still cached: `__result[id]` asks whether
+the module has run, which is not the same question as whether it returned
+something.
+*/
+const RUNTIME: &str = r#"local __larvae = {}
+local __result = {}
+local __loading = {}
+
+local function __require(id)
+	local cached = __result[id]
+
+	if cached then
+		return cached.value
+	end
+
+	if __loading[id] then
+		error("cyclic require of " .. id .. ", it is still loading", 2)
+	end
+
+	local thunk = __larvae[id]
+
+	if not thunk then
+		error("no module " .. id .. " in this bundle", 2)
+	end
+
+	__loading[id] = true
+	local value = thunk()
+	__loading[id] = nil
+	__result[id] = { value = value }
+
+	return value
+end
+"#;
+
+/// Write the bundle, entry last so it runs once everything is registered
+pub fn write(modules: &[Module], entry: &str) -> String {
+    let mut out = String::with_capacity(
+        RUNTIME.len() + modules.iter().map(|m| m.source.len() + 64).sum::<usize>(),
+    );
+
+    out.push_str(RUNTIME);
+
+    for module in modules {
+        out.push('\n');
+        out.push_str(&format!("__larvae[{}] = function()\n", quote(&module.id)));
+
+        /*
+        Indented by one tab, which is cosmetic, and otherwise untouched,
+        which is not. A module's own source must reach the runtime byte for
+        byte, or a long string that contains Luau-like text changes meaning.
+        */
+        for line in module.source.lines() {
+            if line.is_empty() {
+                out.push('\n');
+            } else {
+                out.push('\t');
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+
+        out.push_str("end\n");
+    }
+
+    out.push_str(&format!("\nreturn __require({})\n", quote(entry)));
+
+    out
+}
+
+/// A Luau string literal, escaped
+pub fn quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+
+            '\\' => out.push_str("\\\\"),
+
+            '\n' => out.push_str("\\n"),
+
+            '\r' => out.push_str("\\r"),
+
+            c => out.push(c),
+        }
+    }
+
+    out.push('"');
+
+    out
+}
+
+/*
+The id a module is known by inside the bundle.
+
+The path relative to the project root, without its extension. So the id
+reads like the module the author wrote and not like an opaque number, and a
+runtime error names something findable. Separators normalise to `/`, so a
+bundle built on Windows and one built on Linux come out identical.
+*/
+pub fn module_id(root: &Path, path: &Path) -> String {
+    let rel = path.strip_prefix(root).unwrap_or(path);
+
+    let text = rel.to_string_lossy().replace('\\', "/");
+
+    text.strip_suffix(".luau")
+        .or_else(|| text.strip_suffix(".lua"))
+        .unwrap_or(&text)
+        .to_string()
+}
+
+/*
+The order thunks are written in, dependencies first where such an order
+exists.
+
+Only for reproducibility, per the note at the top: the runtime does not
+care. A cyclic graph has no topological order, so those modules fall back to
+sorted by path, which is arbitrary but stable.
+*/
+pub fn emission_order(
+    graph: &crate::requires::graph::Graph,
+    reachable: &BTreeMap<PathBuf, String>,
+) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = match graph.topological() {
+        Some(order) => order
+            .into_iter()
+            .filter(|p| reachable.contains_key(p))
+            .collect(),
+
+        None => Vec::new(),
+    };
+
+    // Anything the sort could not place, which is every module when cyclic.
+    let mut rest: Vec<PathBuf> = reachable
+        .keys()
+        .filter(|p| !out.contains(p))
+        .cloned()
+        .collect();
+
+    rest.sort();
+    out.extend(rest);
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn module(id: &str, source: &str) -> Module {
+        Module {
+            id: id.to_string(),
+            source: source.to_string(),
+        }
+    }
+
+    #[test]
+    fn the_bundle_registers_every_module_and_returns_the_entry() {
+        let out = write(&[module("a", "return 1"), module("b", "return 2")], "a");
+
+        assert!(out.contains(r#"__larvae["a"] = function()"#), "{out}");
+        assert!(out.contains(r#"__larvae["b"] = function()"#), "{out}");
+        assert!(
+            out.trim_end().ends_with(r#"return __require("a")"#),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn a_module_body_is_indented_but_otherwise_untouched() {
+        let out = write(&[module("a", "local x = 1\nreturn x")], "a");
+
+        assert!(out.contains("\tlocal x = 1\n\treturn x\n"), "{out}");
+    }
+
+    /// An indented blank line is trailing whitespace, which nothing wants
+    #[test]
+    fn a_blank_line_in_a_module_stays_blank() {
+        let out = write(&[module("a", "local x = 1\n\nreturn x")], "a");
+
+        assert!(!out.contains("\t\n"), "indented a blank line: {out:?}");
+    }
+
+    #[test]
+    fn the_runtime_comes_before_any_module() {
+        let out = write(&[module("a", "return 1")], "a");
+        let runtime = out.find("local function __require").expect("runtime");
+        let first = out.find("__larvae[").expect("a module");
+
+        assert!(runtime < first, "the loader must be defined first");
+    }
+
+    // --- ids ---------------------------------------------------------------
+
+    #[test]
+    fn an_id_is_the_path_without_its_extension() {
+        let id = module_id(Path::new("/p"), Path::new("/p/src/shared/util.luau"));
+
+        assert_eq!(id, "src/shared/util");
+    }
+
+    #[test]
+    fn a_lua_extension_is_stripped_too() {
+        assert_eq!(module_id(Path::new("/p"), Path::new("/p/a.lua")), "a");
+    }
+
+    /// A directory module has no extension; its id is the directory
+    #[test]
+    fn a_directory_node_keeps_its_name() {
+        assert_eq!(
+            module_id(Path::new("/p"), Path::new("/p/src/pkg")),
+            "src/pkg"
+        );
+    }
+
+    /// So a bundle built on Windows matches one built anywhere else
+    #[test]
+    fn separators_are_normalised() {
+        let id = module_id(Path::new("/p"), Path::new("/p/src/a.luau"));
+
+        assert!(!id.contains('\\'), "{id}");
+    }
+
+    // --- quoting -----------------------------------------------------------
+
+    #[test]
+    fn a_quote_or_backslash_in_an_id_is_escaped() {
+        assert_eq!(quote(r#"a"b"#), r#""a\"b""#);
+        assert_eq!(quote(r"a\b"), r#""a\\b""#);
+    }
+
+    #[test]
+    fn a_newline_cannot_break_out_of_the_literal() {
+        assert_eq!(quote("a\nb"), r#""a\nb""#);
+    }
+
+    // --- order -------------------------------------------------------------
+
+    fn graph_of(edges: &[(&str, &str)]) -> crate::requires::graph::Graph {
+        let mut g = crate::requires::graph::Graph::default();
+
+        for (from, to) in edges {
+            g.add(Path::new(from), Path::new(to));
+        }
+
+        g
+    }
+
+    fn reachable(names: &[&str]) -> BTreeMap<PathBuf, String> {
+        names
+            .iter()
+            .map(|n| (PathBuf::from(*n), (*n).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn dependencies_are_written_before_the_modules_that_need_them() {
+        let g = graph_of(&[("a", "b"), ("b", "c")]);
+        let order = emission_order(&g, &reachable(&["a", "b", "c"]));
+
+        let at = |s: &str| order.iter().position(|p| p == Path::new(s)).unwrap();
+
+        assert!(at("c") < at("b") && at("b") < at("a"), "{order:?}");
+    }
+
+    /// No topological order exists, and the output must stay stable
+    #[test]
+    fn a_cyclic_graph_still_emits_every_module_in_a_stable_order() {
+        let g = graph_of(&[("a", "b"), ("b", "a")]);
+        let names = reachable(&["a", "b"]);
+
+        let once = emission_order(&g, &names);
+        let twice = emission_order(&g, &names);
+
+        assert_eq!(once, twice);
+        assert_eq!(once.len(), 2);
+    }
+
+    #[test]
+    fn a_module_outside_the_reachable_set_is_not_emitted() {
+        let g = graph_of(&[("a", "b")]);
+        let order = emission_order(&g, &reachable(&["a"]));
+
+        assert_eq!(order, [PathBuf::from("a")]);
+    }
+}

--- a/crates/larvae/src/bundle/mod.rs
+++ b/crates/larvae/src/bundle/mod.rs
@@ -1,0 +1,455 @@
+/*!
+`larvae bundle`, the whole project as one file.
+
+Two halves. This one decides *which* modules are in and rewrites their
+requires to point at each other; [`emit`] decides what the file looks like
+and holds the runtime that makes it behave.
+
+## What it is for
+
+Roblox has no payload pressure, so a bundle here is not about bytes. It is
+for the cases where a tree of modules must arrive as one instance: a plugin,
+a library published as a single ModuleScript, a script pasted into a place
+file.
+
+## Reachability
+
+The plan collects modules with a walk over the requires from the entry, not
+with a list of the input directory. So a bundle contains what the entry can
+reach. That walk is also the dead code elimination: the walk never visits a
+module that nothing requires, so the bundle never contains it, and no
+separate pass is necessary.
+
+The cost of that is dynamic requires. The walk cannot follow
+`require(someVariable)`, so a module reached only that way is not in the
+bundle, and the call fails at run time. The rewrite reports a dynamic
+require in a bundled module, so the problem does not wait for run time.
+*/
+
+pub mod emit;
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+
+use crate::diag::Diag;
+use crate::requires::graph::Graph;
+
+/// Everything a bundle needs, worked out before a byte is written
+pub struct Plan {
+    /// Every module in the bundle, by path, with the id it is known by
+    pub modules: BTreeMap<PathBuf, String>,
+    pub graph: Graph,
+    /// The entry, in the node form of the graph
+    pub entry: PathBuf,
+    /// The findings of the walk, for the caller to print
+    pub diags: Vec<Diag>,
+}
+
+/*
+Walk out from the entry, and collect what it can reach.
+
+The walk runs over the already resolved graph and does not resolve again. So
+the bundle agrees with `check` about what requires what by construction: two
+passes that resolve independently are two chances to disagree.
+
+With `tree_shake` off, every module of the project enters the bundle, the
+unreachable ones included. A project keeps them for the requires the walk
+cannot follow: a dynamic require finds its module in the registry at run
+time only when the bundle contains it.
+*/
+pub fn plan(root: &Path, entry: &Path, graph: &Graph, tree_shake: bool) -> Result<Plan> {
+    if !entry.exists() {
+        bail!("the bundle entry {} does not exist", crate::ui::rel(entry));
+    }
+
+    let entry = entry
+        .canonicalize()
+        .with_context(|| format!("cannot resolve {}", crate::ui::rel(entry)))?;
+
+    // An init file keys on its directory in the graph, so the entry must
+    // take the same form, or the walk starts on a node with no edges.
+    let entry = crate::requires::graph::node_of(&entry).to_path_buf();
+
+    let mut modules: BTreeMap<PathBuf, String> = BTreeMap::new();
+    let mut queue = vec![entry.clone()];
+
+    while let Some(path) = queue.pop() {
+        if modules.contains_key(&path) {
+            continue;
+        }
+
+        modules.insert(path.clone(), emit::module_id(root, &path));
+
+        for to in graph.requires_of(&path) {
+            if !modules.contains_key(to) {
+                queue.push(to.clone());
+            }
+        }
+    }
+
+    if !tree_shake {
+        for node in graph.nodes() {
+            if !modules.contains_key(node) {
+                modules.insert(node.to_path_buf(), emit::module_id(root, node));
+            }
+        }
+    }
+
+    /*
+    A worm that owns its requires resolves them out of sight, so the graph
+    has no edges for the file. The walk cannot follow what it cannot see,
+    and silence here would turn that into a missing module at run time.
+    */
+    let diags = modules
+        .keys()
+        .filter(|path| graph.is_opaque(path))
+        .map(|path| {
+            Diag::warning(
+                path,
+                "a worm resolves the requires of this module, so the bundle cannot follow them",
+            )
+            .with_help("a module reached only through this one is not in the bundle")
+        })
+        .collect();
+
+    Ok(Plan {
+        modules,
+        graph: graph.clone(),
+        entry,
+        diags,
+    })
+}
+
+/*
+One module's source, with every require pointing into the bundle instead.
+
+The spans come from the require sites of the graph, not from a new
+resolution: a site holds the byte range of the string token, and nothing
+about the rewrite needs a parse. The splices apply back to front, so every
+earlier offset stays valid, for the same reason the edit list elsewhere
+sorts before it applies.
+*/
+pub fn rewrite(src: &str, path: &Path, plan: &Plan, diags: &mut Vec<Diag>) -> Result<String> {
+    let lexed = crate::syntax::lexer::lex(src)
+        .map_err(|e| anyhow::anyhow!("{} at byte {}", e.message, e.offset))
+        .with_context(|| format!("cannot bundle {}", crate::ui::rel(path)))?;
+
+    let scanned = crate::syntax::scan::scan(src, &lexed.toks);
+
+    /*
+    A require whose argument is not a literal cannot be followed, so what it
+    names can be missing from the bundle. This is the only chance to say so:
+    at run time it is a missing module with no clue where it came from.
+    */
+    for site in &scanned.dynamic {
+        diags.push(
+            Diag::warning(
+                path,
+                "this require is computed, so what it names cannot be bundled",
+            )
+            .at(src, *site as usize)
+            .with_help("require a literal path, or the call fails inside the bundle"),
+        );
+    }
+
+    let mut out = src.to_string();
+
+    /*
+    Two splices per require: the string token becomes the module id, and the
+    `require` identifier becomes `__require`. One splice for the whole call
+    would need the end of the call, and the scanner does not record it: it
+    records the identifier and the string token, which is enough for both
+    halves. `f "x"` without parentheses is a call too, and the two splices
+    handle it without more knowledge.
+    */
+    for site in plan.graph.sites_of(path).iter().rev() {
+        let Some(id) = plan.modules.get(&site.target) else {
+            continue;
+        };
+
+        out.replace_range(
+            site.tok_start as usize..site.tok_end as usize,
+            &emit::quote(id),
+        );
+
+        out.replace_range(
+            site.at as usize..site.at as usize + "require".len(),
+            "__require",
+        );
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graph_of(edges: &[(&str, &str)]) -> Graph {
+        let mut g = Graph::default();
+
+        for (from, to) in edges {
+            g.add(Path::new(from), Path::new(to));
+        }
+
+        g
+    }
+
+    /// A plan checks that the entry exists, so the walk needs a real tree
+    fn tree(files: &[&str]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+
+        for f in files {
+            let path = dir.path().join(f);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, "return 1\n").unwrap();
+        }
+
+        dir
+    }
+
+    #[test]
+    fn the_plan_reaches_every_module_the_entry_requires() {
+        let dir = tree(&["a.luau", "b.luau", "c.luau"]);
+        let root = dir.path().canonicalize().unwrap();
+
+        let g = graph_of(&[
+            (
+                root.join("a.luau").to_str().unwrap(),
+                root.join("b.luau").to_str().unwrap(),
+            ),
+            (
+                root.join("b.luau").to_str().unwrap(),
+                root.join("c.luau").to_str().unwrap(),
+            ),
+        ]);
+
+        let plan = plan(&root, &root.join("a.luau"), &g, true).unwrap();
+
+        assert_eq!(plan.modules.len(), 3, "{:?}", plan.modules);
+    }
+
+    /// The dead code elimination, which is the walk not visiting it
+    #[test]
+    fn a_module_the_entry_cannot_reach_is_left_out() {
+        let dir = tree(&["a.luau", "b.luau", "orphan.luau"]);
+        let root = dir.path().canonicalize().unwrap();
+
+        let mut g = graph_of(&[(
+            root.join("a.luau").to_str().unwrap(),
+            root.join("b.luau").to_str().unwrap(),
+        )]);
+        g.see(&root.join("orphan.luau"));
+
+        let plan = plan(&root, &root.join("a.luau"), &g, true).unwrap();
+
+        assert_eq!(plan.modules.len(), 2);
+        assert!(!plan.modules.contains_key(&root.join("orphan.luau")));
+    }
+
+    /// With tree_shake off, the walk result grows to the whole project
+    #[test]
+    fn without_tree_shaking_every_module_is_in() {
+        let dir = tree(&["a.luau", "b.luau", "orphan.luau"]);
+        let root = dir.path().canonicalize().unwrap();
+
+        let mut g = graph_of(&[(
+            root.join("a.luau").to_str().unwrap(),
+            root.join("b.luau").to_str().unwrap(),
+        )]);
+        g.see(&root.join("orphan.luau"));
+
+        let plan = plan(&root, &root.join("a.luau"), &g, false).unwrap();
+
+        assert!(plan.modules.contains_key(&root.join("orphan.luau")));
+    }
+
+    /// A cycle must not make the walk loop
+    #[test]
+    fn a_cycle_terminates_and_includes_both_modules() {
+        let dir = tree(&["a.luau", "b.luau"]);
+        let root = dir.path().canonicalize().unwrap();
+
+        let (a, b) = (root.join("a.luau"), root.join("b.luau"));
+        let g = graph_of(&[
+            (a.to_str().unwrap(), b.to_str().unwrap()),
+            (b.to_str().unwrap(), a.to_str().unwrap()),
+        ]);
+
+        let plan = plan(&root, &a, &g, true).unwrap();
+
+        assert_eq!(plan.modules.len(), 2);
+    }
+
+    /// The graph keys an init file on its directory, and the entry must match
+    #[test]
+    fn an_init_file_entry_walks_from_its_directory_node() {
+        let dir = tree(&["pkg/init.luau", "pkg/helper.luau"]);
+        let root = dir.path().canonicalize().unwrap();
+
+        let g = graph_of(&[(
+            root.join("pkg").to_str().unwrap(),
+            root.join("pkg/helper.luau").to_str().unwrap(),
+        )]);
+
+        let plan = plan(&root, &root.join("pkg/init.luau"), &g, true).unwrap();
+
+        assert_eq!(plan.entry, root.join("pkg"));
+        assert_eq!(plan.modules.len(), 2, "{:?}", plan.modules);
+    }
+
+    #[test]
+    fn a_missing_entry_is_an_error_naming_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let Err(err) = plan(
+            dir.path(),
+            &dir.path().join("nope.luau"),
+            &Graph::default(),
+            true,
+        ) else {
+            panic!("there is no entry there to plan from")
+        };
+
+        assert!(format!("{err:#}").contains("nope.luau"));
+    }
+
+    /// The walk cannot follow the requires of an opaque module
+    #[test]
+    fn an_opaque_module_in_the_bundle_is_reported() {
+        let dir = tree(&["a.luau", "styled.luau"]);
+        let root = dir.path().canonicalize().unwrap();
+
+        let mut g = graph_of(&[(
+            root.join("a.luau").to_str().unwrap(),
+            root.join("styled.luau").to_str().unwrap(),
+        )]);
+        g.see_opaque(&root.join("styled.luau"));
+
+        let plan = plan(&root, &root.join("a.luau"), &g, true).unwrap();
+
+        assert_eq!(plan.diags.len(), 1, "{:?}", plan.diags);
+        assert!(plan.diags[0].file.ends_with("styled.luau"));
+    }
+
+    // --- rewriting -----------------------------------------------------------
+
+    /// `src` matters: the site spans must match the text under rewrite
+    fn one_module_plan(root: &Path, from: &Path, to: &Path, src: &str) -> Plan {
+        let mut modules = BTreeMap::new();
+        modules.insert(from.to_path_buf(), emit::module_id(root, from));
+        modules.insert(to.to_path_buf(), emit::module_id(root, to));
+
+        let mut graph = graph_of(&[(from.to_str().unwrap(), to.to_str().unwrap())]);
+
+        let lexed = crate::syntax::lexer::lex(src).unwrap();
+
+        for site in crate::syntax::scan::scan(src, &lexed.toks).sites {
+            graph.add_site(
+                from,
+                crate::requires::graph::Site {
+                    at: site.at,
+                    tok_start: site.tok_start,
+                    tok_end: site.tok_end,
+                    target: to.to_path_buf(),
+                },
+            );
+        }
+
+        Plan {
+            modules,
+            graph,
+            entry: from.to_path_buf(),
+            diags: Vec::new(),
+        }
+    }
+
+    fn empty_plan(entry: &Path) -> Plan {
+        Plan {
+            modules: BTreeMap::new(),
+            graph: Graph::default(),
+            entry: entry.to_path_buf(),
+            diags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_require_becomes_a_call_into_the_bundle() {
+        let root = Path::new("/p");
+        let (a, b) = (Path::new("/p/a.luau"), Path::new("/p/b.luau"));
+        let src = "local x = require(\"./b\")\n";
+        let plan = one_module_plan(root, a, b, src);
+
+        assert_eq!(
+            rewrite(src, a, &plan, &mut Vec::new()).unwrap(),
+            "local x = __require(\"b\")\n"
+        );
+    }
+
+    #[test]
+    fn the_rest_of_the_line_is_untouched() {
+        let root = Path::new("/p");
+        let (a, b) = (Path::new("/p/a.luau"), Path::new("/p/b.luau"));
+        let src = "local x = require(\"./b\").field -- note\n";
+        let plan = one_module_plan(root, a, b, src);
+
+        assert_eq!(
+            rewrite(src, a, &plan, &mut Vec::new()).unwrap(),
+            "local x = __require(\"b\").field -- note\n"
+        );
+    }
+
+    /// The walk cannot follow it, and a discovery at run time is much worse
+    #[test]
+    fn a_computed_require_is_reported() {
+        let a = Path::new("/p/a.luau");
+        let plan = empty_plan(a);
+
+        let mut diags = Vec::new();
+        rewrite("local x = require(name)\n", a, &plan, &mut diags).unwrap();
+
+        assert_eq!(diags.len(), 1);
+        assert!(
+            diags[0].message.contains("computed"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    /// The graph deduplicates edges. A pairing of sites against edges by
+    /// position rewrote the wrong call the second time a module was required.
+    #[test]
+    fn requiring_one_module_twice_rewrites_both_calls() {
+        let root = Path::new("/p");
+        let (a, b) = (Path::new("/p/a.luau"), Path::new("/p/b.luau"));
+        let src = "local x = require(\"./b\")\nlocal y = require(\"./b\")\n";
+        let plan = one_module_plan(root, a, b, src);
+
+        assert_eq!(
+            rewrite(src, a, &plan, &mut Vec::new()).unwrap(),
+            "local x = __require(\"b\")\nlocal y = __require(\"b\")\n"
+        );
+    }
+
+    #[test]
+    fn a_module_with_no_requires_comes_through_unchanged() {
+        let a = Path::new("/p/a.luau");
+        let plan = empty_plan(a);
+
+        let src = "local x = 1\nreturn x\n";
+
+        assert_eq!(rewrite(src, a, &plan, &mut Vec::new()).unwrap(), src);
+    }
+
+    #[test]
+    fn a_file_that_does_not_lex_is_refused_naming_it() {
+        let a = Path::new("/p/a.luau");
+        let plan = empty_plan(a);
+
+        let err = rewrite("local x = \"unterminated\n", a, &plan, &mut Vec::new())
+            .expect_err("should not lex");
+
+        assert!(format!("{err:#}").contains("a.luau"));
+    }
+}

--- a/crates/larvae/src/cli.rs
+++ b/crates/larvae/src/cli.rs
@@ -39,6 +39,22 @@ enum Command {
         watch: bool,
     },
 
+    /// Collect the modules of the project into one file
+    Bundle {
+        /// The module to start from, defaults to [bundle] entry
+        #[arg(long)]
+        entry: Option<PathBuf>,
+        /// Where to write it, defaults to [bundle] output
+        #[arg(long, short)]
+        out: Option<PathBuf>,
+        /// Path to larvae.toml (defaults to ./larvae.toml when present)
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Merge [profile.<name>] over the config before bundling
+        #[arg(long)]
+        profile: Option<String>,
+    },
+
     /// Validate requires and syntax without writing any output
     Check {
         /// Path to larvae.toml (defaults to ./larvae.toml when present)
@@ -170,6 +186,13 @@ fn run() -> Result<ExitCode> {
             profile,
             watch,
         } => commands::process::run(&root, config, profile, watch),
+
+        Command::Bundle {
+            entry,
+            out,
+            config,
+            profile,
+        } => commands::bundle::run(&root, entry, out, config, profile),
 
         Command::Check { config, profile } => commands::check::run(&root, config, profile),
 

--- a/crates/larvae/src/commands/bundle.rs
+++ b/crates/larvae/src/commands/bundle.rs
@@ -1,0 +1,140 @@
+//! `larvae bundle` collects the modules of the project into one file.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use anyhow::{Context, Result, bail};
+
+use crate::commands::process::load_config;
+use crate::{bundle, pipeline, ui};
+
+pub fn run(
+    root: &Path,
+    entry: Option<PathBuf>,
+    out: Option<PathBuf>,
+    config: Option<PathBuf>,
+    profile: Option<String>,
+) -> Result<ExitCode> {
+    let config = load_config(root, config, profile.as_deref())?;
+
+    /*
+    The command line beats the config, in the same order every other command
+    uses. So a project keeps one entry configured, and bundles a different
+    one once without an edit.
+    */
+    let entry = entry
+        .or_else(|| config.bundle.entry.clone())
+        .context("no bundle entry, pass --entry or set [bundle] entry in larvae.toml")?;
+
+    let out = out
+        .or_else(|| config.bundle.output.clone())
+        .unwrap_or_else(|| PathBuf::from("bundle.luau"));
+
+    // The graph keys on the canonical root, so the entry and the module ids
+    // must join onto the same form.
+    let root = root
+        .canonicalize()
+        .with_context(|| format!("cannot resolve project root {}", root.display()))?;
+
+    /*
+    Resolution runs first and writes nothing. The bundle needs the same
+    require graph that `check` uses, and a second resolution is a second
+    chance for the bundle and the diagnostics to disagree about what
+    requires what. The run also keeps the processed text of each module; see
+    [`pipeline::Outcome::sources`] for why the files on disk are not the
+    source of truth.
+    */
+    let resolved = pipeline::run_keeping_sources(&root, &config)?;
+
+    let color = ui::want_color_stderr();
+
+    for diag in &resolved.diags {
+        eprintln!("{}", diag.render(color));
+    }
+
+    if resolved.has_errors() {
+        bail!("the project does not resolve cleanly, so larvae cannot bundle it");
+    }
+
+    let mut plan = bundle::plan(
+        &root,
+        &root.join(&entry),
+        &resolved.graph,
+        config.bundle.tree_shake,
+    )?;
+    let mut diags = std::mem::take(&mut plan.diags);
+    let mut modules = Vec::new();
+
+    for path in bundle::emit::emission_order(&plan.graph, &plan.modules) {
+        /*
+        The processed text of the pipeline is the source of truth: a
+        front-end worm compiles a claimed file in there, and the require
+        site spans index that exact text. A module without processed text
+        sat outside the input roots, so the pipeline never touched it and no
+        worm claims it; for that module, the file on disk is the text the
+        project runs.
+        */
+        let src = match resolved.sources.get(&path) {
+            Some(text) => text.clone(),
+
+            None => read_module(&path)?,
+        };
+
+        modules.push(bundle::emit::Module {
+            id: plan.modules[&path].clone(),
+            source: bundle::rewrite(&src, &path, &plan, &mut diags)?,
+        });
+    }
+
+    crate::diag::sort(&mut diags);
+
+    for diag in &diags {
+        eprintln!("{}", diag.render(color));
+    }
+
+    let entry_id = plan
+        .modules
+        .get(&plan.entry)
+        .context("the entry is not in its own plan")?;
+
+    let text = bundle::emit::write(&modules, entry_id);
+    let out_path = root.join(&out);
+
+    if let Some(parent) = out_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("cannot create {}", ui::rel(parent)))?;
+    }
+
+    std::fs::write(&out_path, &text)
+        .with_context(|| format!("cannot write {}", ui::rel(&out_path)))?;
+
+    let shaken = resolved.graph.nodes().count().saturating_sub(modules.len());
+
+    ui::print_success(&format!(
+        "bundled {} modules into {}{}",
+        modules.len(),
+        ui::rel(&out_path),
+        match shaken {
+            0 => String::new(),
+
+            n => format!(", {n} unreachable left out"),
+        }
+    ));
+
+    Ok(ExitCode::SUCCESS)
+}
+
+/// A node outside the pipeline; a directory node stands for its init file
+fn read_module(node: &Path) -> Result<String> {
+    let file = if node.is_dir() {
+        ["init.luau", "init.lua"]
+            .iter()
+            .map(|name| node.join(name))
+            .find(|p| p.is_file())
+            .with_context(|| format!("no init file in {}", ui::rel(node)))?
+    } else {
+        node.to_path_buf()
+    };
+
+    std::fs::read_to_string(&file).with_context(|| format!("cannot read {}", ui::rel(&file)))
+}

--- a/crates/larvae/src/commands/check.rs
+++ b/crates/larvae/src/commands/check.rs
@@ -10,7 +10,27 @@ use crate::pipeline;
 
 pub fn run(root: &Path, config: Option<PathBuf>, profile: Option<String>) -> Result<ExitCode> {
     let config = load_config(root, config, profile.as_deref())?;
-    let outcome = pipeline::run(root, &config, false)?;
+    let mut outcome = pipeline::run(root, &config, false)?;
+
+    /*
+    The whole project checks. Each one needs the full graph, so they run
+    after the pipeline resolves every file. `process` does not run them:
+    they are a gate, not a part of producing output, and a cycle does not
+    stop a build.
+
+    The graph keys on the canonical root, so the entries in `[check]` must
+    join onto the same form.
+    */
+    let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+
+    outcome.diags.extend(crate::requires::analyse::run(
+        &outcome.graph,
+        &config.check,
+        &config.requires,
+        &root,
+    ));
+
+    crate::diag::sort(&mut outcome.diags);
 
     report(&outcome, false)
 }

--- a/crates/larvae/src/commands/detect.rs
+++ b/crates/larvae/src/commands/detect.rs
@@ -20,6 +20,69 @@ const PACKAGE_DIRS: [(&str, &str); 6] = [
     ("packages", "pkg"),
 ];
 
+/*
+Returns the alias for a dependency directory, when this path is inside one.
+
+The check reads every component and not only the last one. A package tree is
+usually mounted one level down: `packages/roblox` has the file name `roblox`
+and is still a package directory. A check of the last component alone put
+that mount in `input`, so `larvae init` proposed the dependencies of a
+project as sources.
+
+The check reads the path relative to the project root. The absolute path
+would also match when the repository itself lives under a directory named
+`packages`.
+*/
+fn package_alias(rel: &Path) -> Option<&'static str> {
+    rel.components().find_map(|c| {
+        let name = c.as_os_str().to_str()?;
+
+        PACKAGE_DIRS
+            .iter()
+            .find(|(dir, _)| *dir == name)
+            .map(|(_, alias)| *alias)
+    })
+}
+
+/*
+Folds sibling roots into the directory that holds them.
+
+A Rojo project mounts `src/client`, `src/server` and `src/shared` separately.
+A list of all three roots is noisy, and it causes a later fault: larvae would
+silently skip a file added under `src` before a mount exists for it. One root
+covers the three mounts, and one root is what almost every project means.
+
+The fold applies only to two or more roots, so a project that mounts a single
+subdirectory keeps it. The fold stops at a real shared parent, so unrelated
+roots such as `src` and `assets` stay separate and do not collapse to the
+repository root.
+*/
+fn collapse(inputs: Vec<PathBuf>) -> Vec<PathBuf> {
+    if inputs.len() < 2 {
+        return inputs;
+    }
+
+    let mut shared: Vec<_> = inputs[0].components().collect();
+
+    for path in &inputs[1..] {
+        let other: Vec<_> = path.components().collect();
+        let keep = shared
+            .iter()
+            .zip(&other)
+            .take_while(|(a, b)| a == b)
+            .count();
+
+        shared.truncate(keep);
+    }
+
+    // The roots share only the repository root, so the list stays as it is.
+    if shared.is_empty() {
+        return inputs;
+    }
+
+    vec![shared.iter().collect()]
+}
+
 /// The data that init found for the config
 pub struct Detected {
     /// Mounted source directories that hold code and not dependencies
@@ -33,6 +96,7 @@ pub struct Detected {
 pub fn scan(root: &Path, project: Option<&Project>) -> Detected {
     let mut inputs = Vec::new();
     let mut aliases = Vec::new();
+    let existing = luaurc_aliases(root);
 
     if let Some(p) = project {
         for mount in rojo::mounts(p) {
@@ -40,19 +104,25 @@ pub fn scan(root: &Path, project: Option<&Project>) -> Detected {
                 continue;
             };
 
-            let name = mount
-                .fs
-                .file_name()
-                .and_then(|s| s.to_str())
-                .unwrap_or_default();
+            match package_alias(rel) {
+                /*
+                The directory holds dependencies, so it gets an alias and no
+                processing, unless `.luaurc` already names the alias.
 
-            match PACKAGE_DIRS.iter().find(|(dir, _)| *dir == name) {
-                // The directory holds dependencies, so it gets an alias and no processing.
-                Some((_, alias)) => {
+                larvae reads the `.luaurc` aliases directly. A copy in
+                `larvae.toml` keeps the same fact in a second place and
+                changes nothing. The two spellings also differ: `.luaurc`
+                holds a filesystem path, because an editor can follow one,
+                and the copy would put a DataModel path beside it.
+                */
+                Some(alias) => {
                     let value = format!("@game/{}", mount.dm.join("/"));
 
-                    if !aliases.iter().any(|(a, _): &(String, String)| a == alias) {
-                        aliases.push(((*alias).to_string(), value));
+                    let known = existing.iter().any(|a| a == alias)
+                        || aliases.iter().any(|(a, _): &(String, String)| a == alias);
+
+                    if !known {
+                        aliases.push((alias.to_string(), value));
                     }
                 }
 
@@ -71,11 +141,12 @@ pub fn scan(root: &Path, project: Option<&Project>) -> Detected {
     }
 
     inputs.sort();
+    inputs = collapse(inputs);
 
     Detected {
         inputs,
         aliases,
-        luaurc_aliases: luaurc_aliases(root),
+        luaurc_aliases: existing,
     }
 }
 
@@ -149,8 +220,13 @@ mod tests {
         );
     }
 
+    /*
+    A list of every mount alone would silently skip a file added under `src`
+    before a mount exists for it. So sibling mounts fold into the directory
+    that holds them.
+    */
     #[test]
-    fn several_source_mounts_all_come_back() {
+    fn sibling_mounts_collapse_to_the_directory_holding_them() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
 
@@ -159,17 +235,157 @@ mod tests {
             "default.project.json",
             r#"{ "name": "g", "tree": { "$className": "DataModel",
                  "ReplicatedStorage": { "app": { "$path": "src/shared" } },
-                 "ServerScriptService": { "s": { "$path": "src/server" } } } }"#,
+                 "ServerScriptService": { "s": { "$path": "src/server" } },
+                 "StarterPlayer": { "c": { "$path": "src/client" } } } }"#,
+        );
+
+        for d in ["src/shared", "src/server", "src/client"] {
+            std::fs::create_dir_all(root.join(d)).unwrap();
+        }
+
+        let project = rojo::load(&root.join("default.project.json")).unwrap();
+
+        assert_eq!(scan(root, Some(&project)).inputs, [PathBuf::from("src")]);
+    }
+
+    /// Unrelated roots share only the repository root, and that is not a fold
+    #[test]
+    fn roots_with_nothing_in_common_stay_separate() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(
+            root,
+            "default.project.json",
+            r#"{ "name": "g", "tree": { "$className": "DataModel",
+                 "ReplicatedStorage": { "app": { "$path": "src/shared" } },
+                 "Workspace": { "a": { "$path": "assets/models" } } } }"#,
         );
         std::fs::create_dir_all(root.join("src/shared")).unwrap();
-        std::fs::create_dir_all(root.join("src/server")).unwrap();
+        std::fs::create_dir_all(root.join("assets/models")).unwrap();
+
+        let project = rojo::load(&root.join("default.project.json")).unwrap();
+
+        assert_eq!(
+            scan(root, Some(&project)).inputs,
+            [PathBuf::from("assets/models"), PathBuf::from("src/shared")]
+        );
+    }
+
+    /*
+    A package tree is usually mounted one level down, so `packages/roblox` has
+    the file name `roblox`. A check of the last component alone proposed the
+    dependencies of a project as sources.
+    */
+    #[test]
+    fn a_package_directory_mounted_one_level_down_is_still_a_dependency() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(
+            root,
+            "default.project.json",
+            r#"{ "name": "g", "tree": { "$className": "DataModel",
+                 "ReplicatedStorage": {
+                   "shared":   { "$path": "src/shared" },
+                   "Packages": { "$path": "packages/roblox" } } } }"#,
+        );
+        std::fs::create_dir_all(root.join("src/shared")).unwrap();
+        std::fs::create_dir_all(root.join("packages/roblox")).unwrap();
+
+        let project = rojo::load(&root.join("default.project.json")).unwrap();
+        let found = scan(root, Some(&project));
+
+        assert_eq!(found.inputs, [PathBuf::from("src/shared")], "not an input");
+        assert!(
+            found
+                .aliases
+                .contains(&("pkg".into(), "@game/ReplicatedStorage/Packages".into())),
+            "{:?}",
+            found.aliases
+        );
+    }
+
+    /// A repository that lives under a directory named packages must not match
+    #[test]
+    fn only_the_path_below_the_root_is_checked_for_package_names() {
+        assert_eq!(package_alias(Path::new("packages/roblox")), Some("pkg"));
+        assert_eq!(package_alias(Path::new("src/shared")), None);
+    }
+
+    /*
+    larvae reads the `.luaurc` aliases directly. A copy in `larvae.toml` keeps
+    the same fact in a second place and changes nothing. The two spellings
+    also differ: `.luaurc` holds a filesystem path that an editor can follow,
+    and the copy would put a DataModel path beside it.
+    */
+    #[test]
+    fn an_alias_luaurc_already_defines_is_not_proposed_again() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(
+            root,
+            "default.project.json",
+            r#"{ "name": "g", "tree": { "$className": "DataModel",
+                 "ReplicatedStorage": {
+                   "shared":   { "$path": "src/shared" },
+                   "Packages": { "$path": "packages/roblox" } } } }"#,
+        );
+        write(
+            root,
+            ".luaurc",
+            r#"{ "aliases": { "pkg": "packages/roblox" } }"#,
+        );
+        std::fs::create_dir_all(root.join("src/shared")).unwrap();
+        std::fs::create_dir_all(root.join("packages/roblox")).unwrap();
+
+        let project = rojo::load(&root.join("default.project.json")).unwrap();
+        let found = scan(root, Some(&project));
+
+        assert!(found.aliases.is_empty(), "{:?}", found.aliases);
+        assert_eq!(found.luaurc_aliases, ["pkg"]);
+    }
+
+    /// A package directory that `.luaurc` does not name still gets an alias
+    #[test]
+    fn an_alias_luaurc_does_not_define_is_still_proposed() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(
+            root,
+            "default.project.json",
+            r#"{ "name": "g", "tree": { "$className": "DataModel",
+                 "ReplicatedStorage": {
+                   "shared":   { "$path": "src/shared" },
+                   "Packages": { "$path": "packages/roblox" } } } }"#,
+        );
+        write(
+            root,
+            ".luaurc",
+            r#"{ "aliases": { "shared": "src/shared" } }"#,
+        );
+        std::fs::create_dir_all(root.join("src/shared")).unwrap();
+        std::fs::create_dir_all(root.join("packages/roblox")).unwrap();
 
         let project = rojo::load(&root.join("default.project.json")).unwrap();
         let found = scan(root, Some(&project));
 
         assert_eq!(
-            found.inputs,
-            [PathBuf::from("src/server"), PathBuf::from("src/shared")]
+            found.aliases,
+            [(
+                "pkg".to_string(),
+                "@game/ReplicatedStorage/Packages".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn a_single_mount_is_left_exactly_as_it_is() {
+        assert_eq!(
+            collapse(vec![PathBuf::from("src/shared")]),
+            [PathBuf::from("src/shared")]
         );
     }
 

--- a/crates/larvae/src/commands/mod.rs
+++ b/crates/larvae/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod bundle;
 pub mod check;
 pub mod code;
 pub mod detect;

--- a/crates/larvae/src/commands/mod.rs
+++ b/crates/larvae/src/commands/mod.rs
@@ -6,5 +6,6 @@ pub mod init;
 pub mod lint;
 pub mod process;
 pub mod self_cmd;
+pub mod sync_luaurc;
 pub mod watch;
 pub mod worm;

--- a/crates/larvae/src/commands/self_cmd.rs
+++ b/crates/larvae/src/commands/self_cmd.rs
@@ -1,6 +1,6 @@
 //! `larvae self <command>` manages the larvae installation.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::{Context, Result, bail};
@@ -31,6 +31,16 @@ pub enum SelfCommand {
 
     /// Set up editor completion for larvae.toml
     Code,
+
+    /// Write the project's aliases into .luaurc, as paths an editor can follow
+    SyncLuaurc {
+        /// Write nothing; exit non zero if .luaurc would change
+        #[arg(long)]
+        check: bool,
+        /// Path to larvae.toml (defaults to ./larvae.toml when present)
+        #[arg(long)]
+        config: Option<PathBuf>,
+    },
 }
 
 pub fn run(root: &Path, cmd: SelfCommand) -> Result<ExitCode> {
@@ -42,6 +52,10 @@ pub fn run(root: &Path, cmd: SelfCommand) -> Result<ExitCode> {
         SelfCommand::Uninstall => uninstall(),
 
         SelfCommand::Code => crate::commands::code::run(root),
+
+        SelfCommand::SyncLuaurc { check, config } => {
+            crate::commands::sync_luaurc::run(root, check, config)
+        }
     }
 }
 

--- a/crates/larvae/src/commands/sync_luaurc.rs
+++ b/crates/larvae/src/commands/sync_luaurc.rs
@@ -1,0 +1,510 @@
+/*!
+`larvae self sync-luaurc` writes the project aliases into the `.luaurc` that
+an editor reads.
+
+A `@game/...` alias value is a DataModel path, and luau-lsp cannot follow
+one. A verbatim copy would cost the editor types and go-to-definition on
+every require through that alias. So the command inverts the mount table: the
+DataModel path goes back to the directory that mounts there, and `.luaurc`
+gets a path that the editor can resolve. Rewritten `@game` requires exist
+only under the output directory, which nobody edits. So source keeps its
+`@pkg` forms, and this file backs them.
+
+The command rewrites only the `aliases` key. Other keys survive. Comments do
+not survive, because larvae reads `.luaurc` as JSON with comments and writes
+it back as plain JSON.
+*/
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use anyhow::{Context, Result, bail};
+use serde_json::{Map, Value};
+
+use crate::commands::process::load_config;
+use crate::config::Config;
+use crate::pipeline::setup;
+use crate::project::rojo;
+use crate::requires::datamodel::{MountTable, parse_game_path};
+use crate::ui;
+
+/// The result of one run. The exit code follows from it.
+#[derive(Debug, PartialEq, Eq)]
+enum Outcome {
+    /// The config has no `[aliases]`, so the command has nothing to write
+    Empty,
+    UpToDate,
+    Wrote(usize),
+    /// `--check` found work and did not do it
+    WouldChange,
+}
+
+pub fn run(root: &Path, check: bool, config: Option<PathBuf>) -> Result<ExitCode> {
+    let path = root.join(".luaurc");
+
+    match sync(root, check, config)? {
+        Outcome::Empty => {
+            ui::print_success("no [aliases] to sync, .luaurc left alone");
+
+            Ok(ExitCode::SUCCESS)
+        }
+
+        Outcome::UpToDate => {
+            ui::print_success(&format!("{} is already in sync", ui::rel(&path)));
+
+            Ok(ExitCode::SUCCESS)
+        }
+
+        Outcome::Wrote(n) => {
+            ui::print_success(&format!("synced {n} aliases into {}", ui::rel(&path)));
+
+            Ok(ExitCode::SUCCESS)
+        }
+
+        Outcome::WouldChange => {
+            println!("would update {}", ui::rel(&path));
+
+            Ok(ExitCode::FAILURE)
+        }
+    }
+}
+
+/*
+The whole job, without the reporting.
+
+The split gives `--check` and the tests an answer rather than an exit code.
+The function also touches the file only when its bytes change. So a synced
+project does not trigger the watchers that read `.luaurc`.
+*/
+fn sync(root: &Path, check: bool, config: Option<PathBuf>) -> Result<Outcome> {
+    let cfg = load_config(root, config, None)?;
+
+    // The mounts hold absolute paths, so the root must be absolute too.
+    let root = root
+        .canonicalize()
+        .with_context(|| format!("cannot resolve project root {}", root.display()))?;
+
+    let aliases = resolve(&root, &cfg)?;
+
+    if aliases.is_empty() {
+        return Ok(Outcome::Empty);
+    }
+
+    let path = root.join(".luaurc");
+
+    let current = match path.exists() {
+        true => Some(
+            std::fs::read_to_string(&path)
+                .with_context(|| format!("failed to read {}", ui::rel(&path)))?,
+        ),
+
+        false => None,
+    };
+
+    let next = merge(current.as_deref(), &aliases)
+        .with_context(|| format!("failed to update {}", ui::rel(&path)))?;
+
+    if current.as_deref() == Some(next.as_str()) {
+        return Ok(Outcome::UpToDate);
+    }
+
+    if check {
+        return Ok(Outcome::WouldChange);
+    }
+
+    std::fs::write(&path, &next).with_context(|| format!("failed to write {}", ui::rel(&path)))?;
+
+    Ok(Outcome::Wrote(aliases.len()))
+}
+
+/*
+Returns every alias as `.luaurc` must carry it, sorted so two runs agree.
+
+The inversion goes through the same mount table that the require rewriter
+builds, from the Rojo project file and `[requires.mounts]` together. An alias
+that resolves to one directory in the editor and to another during a build is
+the exact failure that this command exists to prevent. So the command must
+not build a mount table of its own.
+*/
+fn resolve(root: &Path, config: &Config) -> Result<Vec<(String, String)>> {
+    /*
+    A project file that does not parse is a fatal error here. In the pipeline
+    the same fault degrades into a diagnostic, and the build carries on. Here
+    a broken project leaves the mount table without its mounts, and a missing
+    mount does not fail loudly. It silently becomes "this alias has no
+    preimage".
+    */
+    let project = rojo::find_project(root, config.rojo.project.as_deref())
+        .map(|p| rojo::load(&p))
+        .transpose()?;
+
+    let mut diags = Vec::new();
+    let mounts = setup::mount_table(root, config, project.as_ref(), &mut diags);
+
+    for d in &diags {
+        eprintln!("{}", d.render(ui::want_color_stderr()));
+    }
+
+    let mut out = Vec::new();
+
+    for (name, value) in &config.aliases {
+        out.push((name.clone(), path_value(root, name, value, &mounts)?));
+    }
+
+    out.sort();
+
+    Ok(out)
+}
+
+/// Returns one alias value. The function inverts a DataModel path and keeps any other value.
+fn path_value(root: &Path, name: &str, value: &str, mounts: &MountTable) -> Result<String> {
+    let Some(segments) = parse_game_path(value) else {
+        // The value is already a path, which is what the editor needs.
+        return Ok(value.to_owned());
+    };
+
+    let fs = mounts.fs_of(&segments).with_context(|| {
+        format!(
+            "alias \"@{name}\" = \"{value}\" has no filesystem preimage, nothing mounts at that DataModel path. \
+             Mount it in the Rojo project file or name it in [requires.mounts]"
+        )
+    })?;
+
+    let rel = fs.strip_prefix(root).with_context(|| {
+        format!(
+            "alias \"@{name}\" = \"{value}\" mounts {}, which is outside the project root",
+            fs.display()
+        )
+    })?;
+
+    Ok(slashed(rel))
+}
+
+/// A `.luaurc` path is relative to the file's own directory, with forward slashes on every platform
+fn slashed(rel: &Path) -> String {
+    let joined = rel
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect::<Vec<_>>()
+        .join("/");
+
+    match joined.is_empty() {
+        // The mount is the project root itself.
+        true => "./".to_string(),
+
+        false => format!("./{joined}"),
+    }
+}
+
+/*
+Lays the alias table over what `.luaurc` already says.
+
+The merge goes per key and not wholesale, because `[aliases]` in larvae.toml
+also merges over `.luaurc` per key. A replaced table would delete aliases
+that larvae still honors, and the editor would stop resolving requires that
+build without errors. Names match case insensitively, because Luau resolves
+them that way. So a config `Pkg` updates an existing `pkg` and does not sit
+beside it as a second entry that nothing can tell apart.
+*/
+fn merge(current: Option<&str>, aliases: &[(String, String)]) -> Result<String> {
+    let mut doc = match current {
+        // `.luaurc` is JSON with comments, and json5 accepts a superset of that.
+        Some(text) => json5::from_str::<Value>(text).context("not valid JSON")?,
+
+        None => Value::Object(Map::new()),
+    };
+
+    let Some(obj) = doc.as_object_mut() else {
+        bail!("the file is not a JSON object");
+    };
+
+    let table = obj
+        .entry("aliases")
+        .or_insert_with(|| Value::Object(Map::new()));
+
+    let Some(table) = table.as_object_mut() else {
+        bail!("the \"aliases\" key is not a JSON object");
+    };
+
+    for (name, value) in aliases {
+        let key = table
+            .keys()
+            .find(|k| k.trim_start_matches('@').eq_ignore_ascii_case(name))
+            .cloned()
+            .unwrap_or_else(|| name.clone());
+
+        table.insert(key, Value::String(value.clone()));
+    }
+
+    let mut text = serde_json::to_string_pretty(&doc)?;
+    text.push('\n');
+
+    Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PROJECT: &str = r#"{
+        "name": "game",
+        "tree": {
+            "$className": "DataModel",
+            "ReplicatedStorage": {
+                "shared": { "$path": "src/shared" },
+                "Packages": { "$path": "Packages" }
+            },
+
+            "ServerScriptService": { "$path": "src/server" }
+        }
+    }"#;
+
+    fn write(root: &Path, rel: &str, text: &str) {
+        let path = root.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, text).unwrap();
+    }
+
+    /// Returns the alias table as it landed in `.luaurc`
+    fn aliases_of(root: &Path) -> Map<String, Value> {
+        let text = std::fs::read_to_string(root.join(".luaurc")).unwrap();
+        let doc: Value = json5::from_str(&text).unwrap();
+
+        doc.get("aliases").unwrap().as_object().unwrap().clone()
+    }
+
+    #[test]
+    fn a_game_alias_is_inverted_through_the_rojo_mount() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(root, "default.project.json", PROJECT);
+        write(
+            root,
+            "larvae.toml",
+            "[aliases]\npkg = \"@game/ReplicatedStorage/Packages\"\n",
+        );
+        std::fs::create_dir_all(root.join("Packages")).unwrap();
+
+        assert_eq!(sync(root, false, None).unwrap(), Outcome::Wrote(1));
+        assert_eq!(aliases_of(root)["pkg"], "./Packages");
+    }
+
+    /// A mount that ends above the alias must still resolve the segments below it
+    #[test]
+    fn a_game_alias_below_a_mount_keeps_the_remaining_segments() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(root, "default.project.json", PROJECT);
+        write(
+            root,
+            "larvae.toml",
+            "[aliases]\nui = \"@game/ReplicatedStorage/shared/ui\"\n",
+        );
+
+        sync(root, false, None).unwrap();
+
+        assert_eq!(aliases_of(root)["ui"], "./src/shared/ui");
+    }
+
+    #[test]
+    fn a_mount_named_in_the_config_inverts_without_a_project_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(
+            root,
+            "larvae.toml",
+            "[aliases]\npkg = \"@game/ReplicatedStorage/Packages\"\n\
+             \n[requires.mounts]\n\"vendor/pkgs\" = \"@game/ReplicatedStorage/Packages\"\n",
+        );
+
+        sync(root, false, None).unwrap();
+
+        assert_eq!(aliases_of(root)["pkg"], "./vendor/pkgs");
+    }
+
+    #[test]
+    fn a_filesystem_alias_passes_through_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(root, "default.project.json", PROJECT);
+        write(
+            root,
+            "larvae.toml",
+            "[aliases]\nshared = \"./src/shared\"\nnm = \"node_modules/sig\"\n",
+        );
+
+        sync(root, false, None).unwrap();
+
+        let aliases = aliases_of(root);
+        assert_eq!(aliases["shared"], "./src/shared");
+        assert_eq!(aliases["nm"], "node_modules/sig");
+    }
+
+    /// `@gameplay` is not `@game`. An inversion would look up a service that does not exist.
+    #[test]
+    fn a_value_that_only_starts_like_a_game_path_is_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(root, "default.project.json", PROJECT);
+        write(root, "larvae.toml", "[aliases]\ngp = \"@gameplay/thing\"\n");
+
+        sync(root, false, None).unwrap();
+
+        assert_eq!(aliases_of(root)["gp"], "@gameplay/thing");
+    }
+
+    #[test]
+    fn an_alias_with_no_filesystem_preimage_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(root, "default.project.json", PROJECT);
+        write(
+            root,
+            "larvae.toml",
+            "[aliases]\nghost = \"@game/ServerStorage/nowhere\"\n",
+        );
+
+        let err = format!("{:#}", sync(root, false, None).unwrap_err());
+
+        assert!(err.contains("@ghost"), "{err}");
+        assert!(err.contains("no filesystem preimage"), "{err}");
+        assert!(
+            !root.join(".luaurc").exists(),
+            "nothing should have been written"
+        );
+    }
+
+    #[test]
+    fn other_luaurc_keys_and_aliases_survive_the_sync() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(root, "default.project.json", PROJECT);
+        write(
+            root,
+            "larvae.toml",
+            "[aliases]\npkg = \"@game/ReplicatedStorage/Packages\"\n",
+        );
+        write(
+            root,
+            ".luaurc",
+            r#"{
+                // hand written, and only the alias table is ours
+                "languageMode": "strict",
+                "lint": { "*": true },
+                "aliases": { "local": "./src/local" }
+            }"#,
+        );
+
+        sync(root, false, None).unwrap();
+
+        let text = std::fs::read_to_string(root.join(".luaurc")).unwrap();
+        let doc: Value = json5::from_str(&text).unwrap();
+
+        assert_eq!(doc["languageMode"], "strict");
+        assert_eq!(doc["lint"]["*"], true);
+        // The config does not name this alias, so the sync must not delete it.
+        assert_eq!(doc["aliases"]["local"], "./src/local");
+        assert_eq!(doc["aliases"]["pkg"], "./Packages");
+    }
+
+    /// Luau resolves alias names case insensitively. Two entries that differ
+    /// only in case are one alias with two answers.
+    #[test]
+    fn a_differently_cased_alias_updates_the_existing_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(root, "default.project.json", PROJECT);
+        write(
+            root,
+            "larvae.toml",
+            "[aliases]\nPkg = \"@game/ReplicatedStorage/Packages\"\n",
+        );
+        write(root, ".luaurc", r#"{ "aliases": { "pkg": "./stale" } }"#);
+
+        sync(root, false, None).unwrap();
+
+        let aliases = aliases_of(root);
+        assert_eq!(aliases["pkg"], "./Packages");
+        assert_eq!(aliases.len(), 1, "{aliases:?}");
+    }
+
+    #[test]
+    fn check_writes_nothing_and_reports_that_it_would_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(root, "default.project.json", PROJECT);
+        write(
+            root,
+            "larvae.toml",
+            "[aliases]\npkg = \"@game/ReplicatedStorage/Packages\"\n",
+        );
+        write(root, ".luaurc", "{ \"aliases\": { \"pkg\": \"./stale\" } }");
+
+        assert_eq!(sync(root, true, None).unwrap(), Outcome::WouldChange);
+        assert_eq!(
+            std::fs::read_to_string(root.join(".luaurc")).unwrap(),
+            "{ \"aliases\": { \"pkg\": \"./stale\" } }"
+        );
+    }
+
+    /// A second run must change nothing, or `--check` fails on a tree that just synced
+    #[test]
+    fn a_synced_project_is_up_to_date_under_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(root, "default.project.json", PROJECT);
+        write(
+            root,
+            "larvae.toml",
+            "[aliases]\npkg = \"@game/ReplicatedStorage/Packages\"\nsrv = \"@game/ServerScriptService\"\n",
+        );
+
+        assert_eq!(sync(root, false, None).unwrap(), Outcome::Wrote(2));
+        assert_eq!(sync(root, false, None).unwrap(), Outcome::UpToDate);
+        assert_eq!(sync(root, true, None).unwrap(), Outcome::UpToDate);
+    }
+
+    #[test]
+    fn a_project_with_no_aliases_leaves_luaurc_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(root, "default.project.json", PROJECT);
+        write(root, "larvae.toml", "[process]\ninput = \"src\"\n");
+        write(root, ".luaurc", r#"{ "languageMode": "strict" }"#);
+
+        assert_eq!(sync(root, false, None).unwrap(), Outcome::Empty);
+        assert_eq!(
+            std::fs::read_to_string(root.join(".luaurc")).unwrap(),
+            r#"{ "languageMode": "strict" }"#
+        );
+    }
+
+    #[test]
+    fn a_luaurc_that_is_not_json_fails_naming_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        write(root, "default.project.json", PROJECT);
+        write(
+            root,
+            "larvae.toml",
+            "[aliases]\npkg = \"@game/ReplicatedStorage/Packages\"\n",
+        );
+        write(root, ".luaurc", "{ this is not json");
+
+        let err = format!("{:#}", sync(root, false, None).unwrap_err());
+
+        assert!(err.contains(".luaurc"), "{err}");
+    }
+}

--- a/crates/larvae/src/config/bundle.rs
+++ b/crates/larvae/src/config/bundle.rs
@@ -1,0 +1,76 @@
+/*!
+`[bundle]`, single file output.
+*/
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct BundleConfig {
+    /// The module the bundle starts from, relative to the project root
+    #[serde(default)]
+    pub entry: Option<PathBuf>,
+
+    /// Where the single file goes, relative to the project root
+    #[serde(default)]
+    pub output: Option<PathBuf>,
+
+    /*
+    Drop the modules that the entry cannot reach.
+
+    On by default, because it is the reason to bundle at all: a bundle of
+    everything in the project is larger than the project. Reachability comes
+    from the require graph, so a module reached only through a dynamic
+    require would be dropped. That is why a dynamic require in a bundled
+    module is reported and not ignored, and why a project that needs those
+    modules turns this off.
+    */
+    #[serde(default = "yes")]
+    pub tree_shake: bool,
+}
+
+fn yes() -> bool {
+    true
+}
+
+/*
+Through serde and not derived, so `tree_shake` keeps the default its
+attribute names. A derived `Default` gives `false` for a bool and quietly
+disagrees with the config file, which only shows up as a bundle that nobody
+shrank.
+*/
+impl Default for BundleConfig {
+    fn default() -> Self {
+        toml::from_str("").expect("every field has a default")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tree_shaking_is_on_and_the_paths_are_unset_by_default() {
+        let c = BundleConfig::default();
+
+        assert!(c.tree_shake);
+        assert_eq!(c.entry, None);
+        assert_eq!(c.output, None);
+    }
+
+    #[test]
+    fn the_paths_are_read_as_written() {
+        let c: BundleConfig =
+            toml::from_str("entry = \"src/main.luau\"\noutput = \"dist/bundle.luau\"").unwrap();
+
+        assert_eq!(c.entry, Some(PathBuf::from("src/main.luau")));
+        assert_eq!(c.output, Some(PathBuf::from("dist/bundle.luau")));
+    }
+
+    #[test]
+    fn an_unknown_key_is_refused_like_everywhere_else() {
+        assert!(toml::from_str::<BundleConfig>("whoops = true").is_err());
+    }
+}

--- a/crates/larvae/src/config/check.rs
+++ b/crates/larvae/src/config/check.rs
@@ -1,0 +1,121 @@
+/*!
+`[check]`, the CI gate.
+
+Every question here is a whole project question, not a per file one. That is
+why it lives behind its own command and its own table: a cycle is a property
+of the graph, and no module can see from inside itself that nothing requires
+it.
+
+Each check is a level, not a boolean, to match `[lint.rules]`. So a project
+decides in one place what fails CI. `larvae check` reports unresolvable
+requires and realm violations unconditionally, because those are wrong
+rather than untidy.
+*/
+
+use serde::{Deserialize, Serialize};
+
+pub use crate::lint::Level;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub struct CheckConfig {
+    /*
+    Modules that require each other, directly or through a chain.
+
+    The default is a warning, not an error. A cyclic require is legal at
+    runtime and common in Roblox code: a lazy require inside a function
+    breaks the load order cycle on purpose. A build failure on one would
+    reject working projects, so a team that decides against them raises the
+    level.
+    */
+    #[serde(default = "warn")]
+    pub cycles: Level,
+
+    /*
+    Modules that nothing requires.
+
+    Off by default, because larvae cannot always know what runs a module. A
+    Script or a LocalScript is run by Roblox, not required, and is never
+    reported, which covers most files. But a module reached only through a
+    dynamic require, or from outside the project, would be a false positive,
+    and a report that makes a user delete working code is worse than
+    silence.
+    */
+    #[serde(default = "allow")]
+    pub unused_modules: Level,
+
+    /*
+    Client scripts that require through an indexing style that does not
+    wait.
+
+    A LocalScript can run before the instances it needs have replicated. So
+    a require emitted as `Parent.Thing` or `FindFirstChild("Thing")` is a
+    race: it works on a fast join and returns nil on a slow one. The
+    `wait_for_child` style closes the race.
+
+    The check has meaning only for the `roblox-instance` target, because
+    the other targets do not index anything. It reports once per file, not
+    once per require site, because the fix is one config line.
+    */
+    #[serde(default = "warn")]
+    pub early_require: Level,
+
+    /*
+    Extra entry points, for the modules that `unused_modules` cannot infer.
+
+    The paths are relative to the project root. A module in this list counts
+    as one the project runs, so no incoming edge is not a finding for it.
+    */
+    #[serde(default)]
+    pub entries: Vec<std::path::PathBuf>,
+}
+
+fn warn() -> Level {
+    Level::Warn
+}
+
+fn allow() -> Level {
+    Level::Allow
+}
+
+impl Default for CheckConfig {
+    fn default() -> Self {
+        toml::from_str("").expect("every field has a default")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cycles_warn_and_unused_modules_stay_quiet_by_default() {
+        let c = CheckConfig::default();
+
+        assert_eq!(c.cycles, Level::Warn);
+        assert_eq!(c.unused_modules, Level::Allow);
+        assert_eq!(c.early_require, Level::Warn);
+        assert!(c.entries.is_empty());
+    }
+
+    #[test]
+    fn a_project_can_raise_either_to_deny() {
+        let c: CheckConfig =
+            toml::from_str("cycles = \"deny\"\nunused_modules = \"deny\"").unwrap();
+
+        assert_eq!(c.cycles, Level::Deny);
+        assert_eq!(c.unused_modules, Level::Deny);
+    }
+
+    #[test]
+    fn entries_are_read_as_paths() {
+        let c: CheckConfig = toml::from_str("entries = [\"src/boot.luau\"]").unwrap();
+
+        assert_eq!(c.entries, [std::path::PathBuf::from("src/boot.luau")]);
+    }
+
+    #[test]
+    fn an_unknown_key_is_refused_like_everywhere_else() {
+        assert!(toml::from_str::<CheckConfig>("whoops = true").is_err());
+    }
+}

--- a/crates/larvae/src/config/mod.rs
+++ b/crates/larvae/src/config/mod.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 
+pub mod check;
 mod excludes;
 mod overrides;
 mod process;
@@ -58,6 +59,10 @@ pub struct Config {
     #[serde(default)]
     pub worms: Option<toml::Value>,
 
+    /// The `larvae check` gate, see [`check`]
+    #[serde(default)]
+    pub check: check::CheckConfig,
+
     // Parsed so the error can name the new location and not say "unknown key".
     #[serde(default)]
     config: Option<toml::Value>,
@@ -68,9 +73,6 @@ pub struct Config {
 
     #[serde(default)]
     minify: Option<toml::Value>,
-
-    #[serde(default)]
-    check: Option<toml::Value>,
 }
 
 impl Config {
@@ -141,7 +143,6 @@ impl Config {
         let unimplemented: &[(&str, &Option<toml::Value>, &str)] = &[
             ("[bundle]", &self.bundle, "M3"),
             ("[minify]", &self.minify, "M4"),
-            ("[check]", &self.check, "M3"),
         ];
 
         for (name, value, milestone) in unimplemented {
@@ -353,6 +354,15 @@ mod tests {
         let err = c.validate().unwrap_err().to_string();
 
         assert!(err.contains("M3"), "{err}");
+    }
+
+    /// [check] landed, so a [check] table is configuration and not an error
+    #[test]
+    fn a_check_table_is_read_rather_than_refused() {
+        let c: Config = toml::from_str("[check]\ncycles = \"deny\"").unwrap();
+
+        c.validate().unwrap();
+        assert_eq!(c.check.cycles, crate::lint::Level::Deny);
     }
 
     #[test]

--- a/crates/larvae/src/config/mod.rs
+++ b/crates/larvae/src/config/mod.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 
+pub mod bundle;
 pub mod check;
 mod excludes;
 mod overrides;
@@ -63,14 +64,15 @@ pub struct Config {
     #[serde(default)]
     pub check: check::CheckConfig,
 
+    /// The `larvae bundle` output, see [`bundle`]
+    #[serde(default)]
+    pub bundle: bundle::BundleConfig,
+
     // Parsed so the error can name the new location and not say "unknown key".
     #[serde(default)]
     config: Option<toml::Value>,
 
     // Parsed but not implemented, so the error can name the milestone.
-    #[serde(default)]
-    bundle: Option<toml::Value>,
-
     #[serde(default)]
     minify: Option<toml::Value>,
 }
@@ -140,10 +142,8 @@ impl Config {
             );
         }
 
-        let unimplemented: &[(&str, &Option<toml::Value>, &str)] = &[
-            ("[bundle]", &self.bundle, "M3"),
-            ("[minify]", &self.minify, "M4"),
-        ];
+        let unimplemented: &[(&str, &Option<toml::Value>, &str)] =
+            &[("[minify]", &self.minify, "M4")];
 
         for (name, value, milestone) in unimplemented {
             if value.is_some() {
@@ -350,10 +350,10 @@ mod tests {
 
     #[test]
     fn unimplemented_sections_error_with_milestone() {
-        let c: Config = toml::from_str("[bundle]\nentry = \"src/init.luau\"").unwrap();
+        let c: Config = toml::from_str("[minify]\ncolumn_span = 100").unwrap();
         let err = c.validate().unwrap_err().to_string();
 
-        assert!(err.contains("M3"), "{err}");
+        assert!(err.contains("M4"), "{err}");
     }
 
     /// [check] landed, so a [check] table is configuration and not an error
@@ -363,6 +363,19 @@ mod tests {
 
         c.validate().unwrap();
         assert_eq!(c.check.cycles, crate::lint::Level::Deny);
+    }
+
+    /// [bundle] landed, so a [bundle] table is configuration and not an error
+    #[test]
+    fn a_bundle_table_is_read_rather_than_refused() {
+        let c: Config = toml::from_str("[bundle]\nentry = \"src/init.luau\"").unwrap();
+
+        c.validate().unwrap();
+        assert_eq!(
+            c.bundle.entry,
+            Some(std::path::PathBuf::from("src/init.luau"))
+        );
+        assert!(c.bundle.tree_shake);
     }
 
     #[test]

--- a/crates/larvae/src/fmt/config.rs
+++ b/crates/larvae/src/fmt/config.rs
@@ -98,6 +98,27 @@ pub enum IndentType {
     Spaces,
 }
 
+/*
+Selects which keyword binds a required module.
+
+`preserve` is the default for two reasons. A formatter that changes the
+keyword of a declaration takes a bigger step than a formatter that moves its
+spaces. And Luau enforces `const`: the conversion can turn a file that ran
+into a syntax error, when a later statement reassigns the name. Larvae finds
+that case and keeps `local` there.
+*/
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RequireBinding {
+    /// Keep every declaration exactly as written.
+    #[default]
+    Preserve,
+    /// `const X = require(...)`, where nothing reassigns X.
+    Const,
+    /// `local X = require(...)`.
+    Local,
+}
+
 /// Selects how `sort_requires` groups the requires it sorts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -153,6 +174,10 @@ pub struct FmtConfig {
     pub sort_requires: SortRequires,
 
     // --- options beyond stylua -------------------------------------------
+    /// Selects which keyword binds a required module.
+    #[serde(default)]
+    pub require_binding: RequireBinding,
+
     /*
     A trailing comma that the author left in a table means "keep this table
     expanded".

--- a/crates/larvae/src/fmt/emit.rs
+++ b/crates/larvae/src/fmt/emit.rs
@@ -30,15 +30,24 @@ pub struct Emitter<'a> {
     toks: &'a [Tok],
     trivia: &'a Trivia<'a>,
     cfg: &'a FmtConfig,
+    /// The keywords that `require_binding` decided to change, by their token index
+    rebindings: super::rebind::Rebindings,
 }
 
 impl<'a> Emitter<'a> {
-    pub fn new(src: &'a str, toks: &'a [Tok], trivia: &'a Trivia<'a>, cfg: &'a FmtConfig) -> Self {
+    pub fn new(
+        src: &'a str,
+        toks: &'a [Tok],
+        trivia: &'a Trivia<'a>,
+        cfg: &'a FmtConfig,
+        rebindings: super::rebind::Rebindings,
+    ) -> Self {
         Self {
             src,
             toks,
             trivia,
             cfg,
+            rebindings,
         }
     }
 
@@ -692,7 +701,12 @@ impl<'a> Emitter<'a> {
     }
 
     fn local(&self, n: &Local) -> Doc<'a> {
-        let keyword = self.one(n.keyword);
+        // `require_binding` can decide that this declaration says the other keyword.
+        let keyword = self
+            .rebindings
+            .get(&n.keyword.start)
+            .copied()
+            .unwrap_or_else(|| self.one(n.keyword));
         let names = Doc::join(Doc::text(", "), n.names.iter().map(|b| self.binding(b)));
 
         if n.values.is_empty() {

--- a/crates/larvae/src/fmt/mod.rs
+++ b/crates/larvae/src/fmt/mod.rs
@@ -14,6 +14,7 @@ formatter that oscillates between two outputs turns every save into a diff.
 pub mod config;
 pub mod doc;
 pub mod emit;
+pub mod rebind;
 pub mod trivia;
 
 use anyhow::{Context, Result};
@@ -32,7 +33,8 @@ pub fn format(src: &str, cfg: &FmtConfig) -> Result<String> {
         .context("cannot format a file that does not parse")?;
 
     let trivia = trivia::Trivia::new(src, &lexed.comments);
-    let emitter = emit::Emitter::new(src, &lexed.toks, &trivia, cfg);
+    let rebindings = rebind::plan(src, &lexed.toks, &chunk, cfg.require_binding);
+    let emitter = emit::Emitter::new(src, &lexed.toks, &trivia, cfg, rebindings);
     let document = emitter.chunk(&chunk);
     let out = doc::render(&document, cfg.style());
 
@@ -59,7 +61,12 @@ pub(crate) fn doc_of(src: &str, cfg: &FmtConfig) -> Result<doc::Doc<'static>> {
     let chunk = parser::parse(src, &lexed.toks).map_err(|e| anyhow::anyhow!("{}", e.message))?;
 
     let trivia = trivia::Trivia::new(src, &lexed.comments);
-    let emitter = emit::Emitter::new(src, &lexed.toks, &trivia, cfg);
+
+    /*
+    The slice is not the whole file, so `require_binding` cannot prove that a
+    conversion compiles here. The empty plan changes no keyword.
+    */
+    let emitter = emit::Emitter::new(src, &lexed.toks, &trivia, cfg, rebind::Rebindings::new());
 
     Ok(emitter.block_body(&chunk.block).into_owned())
 }
@@ -73,7 +80,9 @@ pub(crate) fn doc_of_expr(src: &str, cfg: &FmtConfig) -> Result<doc::Doc<'static
         parser::parse_expr(src, &lexed.toks).map_err(|e| anyhow::anyhow!("{}", e.message))?;
 
     let trivia = trivia::Trivia::new(src, &lexed.comments);
-    let emitter = emit::Emitter::new(src, &lexed.toks, &trivia, cfg);
+
+    // An expression declares nothing, so the empty plan is exact here.
+    let emitter = emit::Emitter::new(src, &lexed.toks, &trivia, cfg, rebind::Rebindings::new());
 
     Ok(emitter.expr(&expr).into_owned())
 }

--- a/crates/larvae/src/fmt/rebind.rs
+++ b/crates/larvae/src/fmt/rebind.rs
@@ -1,0 +1,269 @@
+/*!
+Decides which keyword binds each required module, for `require_binding`.
+
+The decision lives here and not in the emitter, because the conversion to
+`const` is the one formatting choice that can stop a file from compiling.
+Luau enforces `const`:
+
+```text
+SyntaxError: Variable 'X' is constant and may not be reassigned
+```
+
+So a name that something reassigns must keep `local`. That knowledge needs
+the scope resolution that the linter already builds. The emitter receives the
+answer as a lookup, and not the machinery that works it out.
+
+The other direction, `const` to `local`, is always safe. It only removes a
+restriction.
+*/
+
+use std::collections::HashMap;
+
+use crate::syntax::ast::*;
+use crate::syntax::lexer::Tok;
+
+use super::config::RequireBinding;
+
+/// Maps a keyword token index to the keyword that must replace it.
+pub type Rebindings = HashMap<u32, &'static str>;
+
+pub fn plan(src: &str, toks: &[Tok], chunk: &Chunk, mode: RequireBinding) -> Rebindings {
+    let mut out = Rebindings::new();
+
+    if mode == RequireBinding::Preserve {
+        return out;
+    }
+
+    /*
+    Only `const` needs the resolution, and the resolution is a whole extra
+    walk of the file. So the safe direction does not pay for it.
+    */
+    let names = match mode {
+        RequireBinding::Const => Some(crate::lint::scope::resolve(src, toks, chunk)),
+
+        _ => None,
+    };
+
+    let mut locals = Vec::new();
+    collect(chunk, &mut locals);
+
+    for local in locals {
+        let Some(binding) = single_require_binding(src, toks, local) else {
+            continue;
+        };
+
+        match mode {
+            RequireBinding::Local if local.is_const => {
+                out.insert(local.keyword.start, "local");
+            }
+
+            RequireBinding::Const if !local.is_const => {
+                let names = names.as_ref().expect("resolved for const");
+
+                // A later statement reassigns the name, so const would be a syntax error.
+                let writable = names
+                    .by_token
+                    .get(&binding.name.start)
+                    .and_then(|&i| names.bindings.get(i))
+                    .is_none_or(|b| !b.writes.is_empty());
+
+                if !writable {
+                    out.insert(local.keyword.start, "const");
+                }
+            }
+
+            _ => {}
+        }
+    }
+
+    out
+}
+
+/*
+Returns the name that a `local X = require(...)` binds, when it is exactly
+that.
+
+The match is narrow on purpose, and it follows the `const_requires` transform
+and the `non_const_require` lint: one name, one value, no type annotation. A
+multi binding cannot be const one name at a time, and an annotated local
+states something that the author cared about.
+*/
+fn single_require_binding<'a>(src: &str, toks: &[Tok], local: &'a Local) -> Option<&'a Binding> {
+    let ([binding], [value]) = (local.names.as_slice(), local.values.as_slice()) else {
+        return None;
+    };
+
+    if binding.ty.is_some() {
+        return None;
+    }
+
+    let Expr::Call { func, method, .. } = value else {
+        return None;
+    };
+
+    if method.is_some() {
+        return None;
+    }
+
+    match func.as_ref() {
+        Expr::Name(n) => (toks[n.start as usize].text(src) == "require").then_some(binding),
+
+        _ => None,
+    }
+}
+
+/*
+Collects every `local` in the file, with the nested ones included.
+
+The walk is written out and does not go through the shared `Visit` trait.
+That trait hands a callback a reference whose lifetime is the visit call and
+not the tree, so the collector cannot store those references.
+*/
+fn collect<'a>(chunk: &'a Chunk, out: &mut Vec<&'a Local>) {
+    block(&chunk.block, out);
+}
+
+fn block<'a>(b: &'a Block, out: &mut Vec<&'a Local>) {
+    for s in &b.stmts {
+        stmt(s, out);
+    }
+}
+
+fn stmt<'a>(s: &'a Stmt, out: &mut Vec<&'a Local>) {
+    match s {
+        Stmt::Local(n) => {
+            out.push(n);
+
+            for v in &n.values {
+                expr(v, out);
+            }
+        }
+
+        Stmt::Assign(n) => {
+            for e in n.targets.iter().chain(&n.values) {
+                expr(e, out);
+            }
+        }
+
+        Stmt::Call(e, _) => expr(e, out),
+
+        Stmt::Return(n) => {
+            for e in &n.values {
+                expr(e, out);
+            }
+        }
+
+        Stmt::Do(n) => block(&n.block, out),
+
+        Stmt::While(n) => {
+            expr(&n.cond, out);
+            block(&n.block, out);
+        }
+
+        Stmt::Repeat(n) => {
+            block(&n.block, out);
+            expr(&n.cond, out);
+        }
+
+        Stmt::If(n) => {
+            for (cond, body) in &n.branches {
+                expr(cond, out);
+                block(body, out);
+            }
+
+            if let Some(body) = &n.else_block {
+                block(body, out);
+            }
+        }
+
+        Stmt::NumericFor(n) => {
+            for e in [&n.start, &n.limit].into_iter().chain(n.step.as_ref()) {
+                expr(e, out);
+            }
+
+            block(&n.block, out);
+        }
+
+        Stmt::GenericFor(n) => {
+            for e in &n.exprs {
+                expr(e, out);
+            }
+
+            block(&n.block, out);
+        }
+
+        Stmt::Function(n) => block(&n.body.block, out),
+
+        Stmt::LocalFunction(n) => block(&n.body.block, out),
+
+        _ => {}
+    }
+}
+
+/// Descends only into the places where a statement can hide, which is a function body.
+fn expr<'a>(e: &'a Expr, out: &mut Vec<&'a Local>) {
+    match e {
+        Expr::Function { body, .. } => block(&body.block, out),
+
+        Expr::Binary { lhs, rhs, .. } => {
+            expr(lhs, out);
+            expr(rhs, out);
+        }
+
+        Expr::Unary { operand, .. } => expr(operand, out),
+
+        Expr::Paren { inner, .. } => expr(inner, out),
+
+        Expr::TypeAssert { expr: inner, .. } => expr(inner, out),
+
+        Expr::Index { object, key, .. } => {
+            expr(object, out);
+
+            if let IndexKey::Computed(k) = key {
+                expr(k, out);
+            }
+        }
+
+        Expr::Call { func, args, .. } => {
+            expr(func, out);
+
+            match args {
+                CallArgs::Paren(list) => list.iter().for_each(|a| expr(a, out)),
+
+                CallArgs::Table(t) => expr(t, out),
+
+                CallArgs::Str(_) => {}
+            }
+        }
+
+        Expr::Table { fields, .. } => {
+            for f in fields {
+                match f {
+                    TableField::Positional(v) => expr(v, out),
+
+                    TableField::Named { value, .. } => expr(value, out),
+
+                    TableField::Computed { key, value } => {
+                        expr(key, out);
+                        expr(value, out);
+                    }
+                }
+            }
+        }
+
+        Expr::IfElse {
+            branches,
+            else_value,
+            ..
+        } => {
+            for (cond, value) in branches {
+                expr(cond, out);
+                expr(value, out);
+            }
+
+            expr(else_value, out);
+        }
+
+        _ => {}
+    }
+}

--- a/crates/larvae/src/lib.rs
+++ b/crates/larvae/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod art;
+pub mod bundle;
 pub mod cache;
 pub mod cli;
 pub mod commands;

--- a/crates/larvae/src/lint/lints/mod.rs
+++ b/crates/larvae/src/lint/lints/mod.rs
@@ -53,6 +53,7 @@ pub static ALL: &[&dyn Lint] = &[
     &roblox::RobloxSuspiciousUdim2New,
     &roblox::RobloxManualFromScaleOrOffset,
     // The lints that selene does not have.
+    &original::NonConstRequire,
     &original::UnreachableCode,
     &original::SelfAssignment,
     &original::StringConcatInLoop,

--- a/crates/larvae/src/lint/lints/original.rs
+++ b/crates/larvae/src/lint/lints/original.rs
@@ -13,6 +13,8 @@ use crate::syntax::ast::*;
 use super::correctness::{each_block, each_stmt};
 
 lints! {
+    NonConstRequire => "non_const_require", Allow,
+        "a required module bound with local, where const says it never changes";
     SelfAssignment => "self_assignment", Warn,
         "assigning a value to itself, which does nothing";
     ShadowedLoopWork => "loop_invariant_call", Warn,
@@ -21,6 +23,104 @@ lints! {
         "building a string by concatenation in a loop, which is quadratic";
     UnreachableCode => "unreachable_code", Warn,
         "statements after a return, break or continue, which never run";
+}
+
+// --- non_const_require -----------------------------------------------------
+
+impl NonConstRequire {
+    /*
+    `local Signal = require(...)`, where `const Signal` says more.
+
+    Luau enforces `const` and does not treat it as decoration: to reassign
+    one is a syntax error, `Variable 'X' is constant and may not be
+    reassigned`. A module handle is the clearest case for it, because a
+    rebind of that name to something else is almost always a mistake and not
+    an intention.
+
+    The lint is off by default. `const` is newer than most codebases, and a
+    project that has not adopted it would get one warning per require on the
+    first run. That is how a linter teaches people to ignore it. `larvae fmt`
+    with `require_binding = "const"` does the whole conversion in one pass,
+    which is the better way to arrive at it.
+
+    The lint is narrow on purpose, and it matches the `const_requires`
+    transform: one name, one value, no type annotation. A multi binding
+    cannot be const one name at a time, and an annotated local states
+    something that the author cared about.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        each_stmt(ctx, out, |ctx, s, out| {
+            let Stmt::Local(n) = s else {
+                return;
+            };
+
+            if n.is_const || !binds_one_require(ctx, n) {
+                return;
+            }
+
+            /*
+            A name that something reassigns cannot be const. Advice to make
+            it const produces `Variable 'X' is constant and may not be
+            reassigned`. The formatter's `require_binding` skips the same
+            case.
+            */
+            let reassigned = ctx
+                .names
+                .by_token
+                .get(&n.names[0].name.start)
+                .and_then(|&i| ctx.names.bindings.get(i))
+                .is_none_or(|b| !b.writes.is_empty());
+
+            if reassigned {
+                return;
+            }
+
+            out.push(
+                Finding::new(
+                    "non_const_require",
+                    ctx.bytes(n.keyword),
+                    format!(
+                        "{} is a required module, so it can be const",
+                        ctx.text(n.names[0].name)
+                    ),
+                )
+                .with_help("const is enforced, reassigning one is a syntax error"),
+            );
+        });
+    }
+}
+
+/// `local X = require(...)`, with one name, one value, and no annotation.
+fn binds_one_require(ctx: &LintCtx<'_>, local: &Local) -> bool {
+    let ([binding], [value]) = (local.names.as_slice(), local.values.as_slice()) else {
+        return false;
+    };
+
+    // An annotation is a statement of the author, so the lint leaves it alone.
+    if binding.ty.is_some() {
+        return false;
+    }
+
+    is_require_call(ctx, value)
+}
+
+/*
+Reports if this expression calls `require`.
+
+The name must be the global one. A local named `require` is the function of
+somebody else and says nothing about modules.
+*/
+fn is_require_call(ctx: &LintCtx<'_>, e: &Expr) -> bool {
+    let Expr::Call { func, method, .. } = e else {
+        return false;
+    };
+
+    if method.is_some() {
+        return false;
+    }
+
+    matches!(func.as_ref(), Expr::Name(n)
+        if ctx.text(*n) == "require" && ctx.names.is_global(n.start))
 }
 
 // --- unreachable_code ------------------------------------------------------

--- a/crates/larvae/src/pipeline/file.rs
+++ b/crates/larvae/src/pipeline/file.rs
@@ -114,6 +114,8 @@ pub(super) struct FileOutcome {
     pub dynamic: usize,
     /// The rules that changed this file, each listed once
     pub applied: Vec<Rule>,
+    /// The modules this file requires; its contribution to the require graph
+    pub required: Vec<std::path::PathBuf>,
 }
 
 /*
@@ -148,6 +150,11 @@ pub(super) fn process_file(
         let last = i + 1 == slots.len();
         let mut edits = Edits::new();
 
+        /*
+        The slot list holds the native slot once, so this pass and its
+        require harvest run once for the file. A later stage extends
+        `applied` only, and adds no edges.
+        */
         if slot == worms.native() {
             outcome = native_pass(
                 path,
@@ -383,6 +390,7 @@ fn native_pass(
         rewrites,
         dynamic: scanned.dynamic.len(),
         applied: Vec::new(),
+        required: ctx.required.take(),
     })
 }
 

--- a/crates/larvae/src/pipeline/file.rs
+++ b/crates/larvae/src/pipeline/file.rs
@@ -116,6 +116,16 @@ pub(super) struct FileOutcome {
     pub applied: Vec<Rule>,
     /// The modules this file requires; its contribution to the require graph
     pub required: Vec<std::path::PathBuf>,
+    /// Each resolved require site, for anything that must rewrite one
+    pub sites: Vec<crate::requires::graph::Site>,
+    /*
+    The text the native pass scanned, kept only when the run asks for it.
+
+    The byte spans in `sites` index this exact text, not the file on disk: a
+    front-end worm replaces the buffer of a claimed file before the scan.
+    The bundler reads modules from here for the same reason.
+    */
+    pub source: Option<String>,
 }
 
 /*
@@ -140,6 +150,8 @@ pub(super) fn process_file(
     worms: &crate::worm::pool::Pool,
     // False when a front-end declares that it resolves its own requires.
     own_requires: bool,
+    // True when the caller wants the scanned text back, see FileOutcome.
+    keep_source: bool,
     diags: &mut Vec<Diag>,
 ) -> Option<FileOutcome> {
     let slots = worms.slots();
@@ -170,6 +182,15 @@ pub(super) fn process_file(
 
             // A file that does not lex is out of the build, later stages included.
             outcome.as_ref()?;
+
+            /*
+            The buffer at the native slot, which is the text the require
+            sites index. A later slot can edit the buffer again, so the copy
+            happens here and not at the end.
+            */
+            if keep_source && let Some(o) = outcome.as_mut() {
+                o.source = Some(current.to_string());
+            }
         } else {
             let Ok(lexed) = lexer::lex(&current) else {
                 continue;
@@ -277,10 +298,30 @@ fn native_pass(
     // requires that point at the same module.
     let mut site_forms: Vec<(scan::RequireSite, String)> = Vec::new();
 
+    // Every site with the module it resolved to, for the require graph.
+    let mut resolved_sites: Vec<crate::requires::graph::Site> = Vec::new();
+
     for site in &scanned.sites {
         let spec = &src[site.inner_start as usize..site.inner_end as usize];
 
-        match resolver.resolve(&ctx, spec, src, site.at as usize, diags) {
+        /*
+        The resolver appends to `ctx.required` when a require resolves to a
+        module. So the entry at the old length, when one exists, is the
+        target of this site.
+        */
+        let before = ctx.required.borrow().len();
+        let rewrite = resolver.resolve(&ctx, spec, src, site.at as usize, diags);
+
+        if let Some(target) = ctx.required.borrow().get(before) {
+            resolved_sites.push(crate::requires::graph::Site {
+                at: site.at,
+                tok_start: site.tok_start,
+                tok_end: site.tok_end,
+                target: target.clone(),
+            });
+        }
+
+        match rewrite {
             Rewrite::Keep => {
                 site_forms.push((*site, spec.to_string()));
                 // Unchanged requires also get the configured quote style.
@@ -391,6 +432,8 @@ fn native_pass(
         dynamic: scanned.dynamic.len(),
         applied: Vec::new(),
         required: ctx.required.take(),
+        sites: resolved_sites,
+        source: None,
     })
 }
 

--- a/crates/larvae/src/pipeline/mod.rs
+++ b/crates/larvae/src/pipeline/mod.rs
@@ -56,6 +56,18 @@ pub struct Outcome {
     only run: the cache applies only to writes.
     */
     pub graph: crate::requires::graph::Graph,
+    /*
+    The processed text of every module, keyed like the graph keys its nodes.
+
+    The bundler reads modules from here and not from disk, for two reasons.
+    A front-end worm compiles a claimed file inside the pipeline, so the
+    file on disk holds markup that is not Luau. And the require sites of the
+    graph hold byte spans, and the spans index this exact text.
+
+    The map fills only on a [`run_keeping_sources`] run, because it holds
+    the whole project in memory.
+    */
+    pub sources: std::collections::BTreeMap<PathBuf, String>,
 }
 
 impl Outcome {
@@ -67,6 +79,21 @@ impl Outcome {
 }
 
 pub fn run(root: &Path, config: &Config, write: bool) -> Result<Outcome> {
+    run_inner(root, config, write, false)
+}
+
+/*
+Run the pipeline without writes, and keep the processed text of every module.
+
+This is the entry for the bundler. The run does not write, so the cache is
+off, and the graph and the sources cover every file. See [`Outcome::sources`]
+for why the bundler must not read the files from disk itself.
+*/
+pub fn run_keeping_sources(root: &Path, config: &Config) -> Result<Outcome> {
+    run_inner(root, config, false, true)
+}
+
+fn run_inner(root: &Path, config: &Config, write: bool, keep_sources: bool) -> Result<Outcome> {
     let root = root
         .canonicalize()
         .with_context(|| format!("cannot resolve project root {}", root.display()))?;
@@ -170,6 +197,7 @@ pub fn run(root: &Path, config: &Config, write: bool) -> Result<Outcome> {
     // --- Parallel per file processing ---------------------------------------
     let shared_diags = Mutex::new(diags);
     let shared_graph = Mutex::new(crate::requires::graph::Graph::default());
+    let shared_sources = Mutex::new(std::collections::BTreeMap::new());
     let stats = Mutex::new(Stats::default());
 
     let fresh_hashes: Mutex<Vec<(String, u64)>> = Mutex::new(Vec::new());
@@ -249,7 +277,7 @@ pub fn run(root: &Path, config: &Config, write: bool) -> Result<Outcome> {
         let owns = pool.owns_requires(front);
 
         let mut local_diags = Vec::new();
-        let rewritten = process_file(
+        let mut rewritten = process_file(
             path,
             &text,
             &rel,
@@ -260,6 +288,7 @@ pub fn run(root: &Path, config: &Config, write: bool) -> Result<Outcome> {
             write,
             &pool,
             owns,
+            keep_sources,
             &mut local_diags,
         );
         let mut s = stats.lock().unwrap();
@@ -296,7 +325,21 @@ pub fn run(root: &Path, config: &Config, write: bool) -> Result<Outcome> {
                 for to in &file.required {
                     g.add(node, to);
                 }
+
+                // The sites key on the node too, so the bundler finds the
+                // sites of an init file under its directory.
+                for site in &file.sites {
+                    g.add_site(node, site.clone());
+                }
             }
+        }
+
+        if let Some(text) = rewritten.as_mut().and_then(|f| f.source.take()) {
+            let node = crate::requires::graph::node_of(path);
+            shared_sources
+                .lock()
+                .unwrap()
+                .insert(node.to_path_buf(), text);
         }
         // Only a clean file gets a cache entry; errors must appear again.
         if rewritten.is_some()
@@ -424,5 +467,6 @@ pub fn run(root: &Path, config: &Config, write: bool) -> Result<Outcome> {
         diags,
         build_project,
         graph: shared_graph.into_inner().unwrap(),
+        sources: shared_sources.into_inner().unwrap(),
     })
 }

--- a/crates/larvae/src/pipeline/mod.rs
+++ b/crates/larvae/src/pipeline/mod.rs
@@ -4,7 +4,7 @@ mod file;
 mod frontend;
 mod output;
 pub mod roots;
-mod setup;
+pub(crate) mod setup;
 
 use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
@@ -49,6 +49,13 @@ pub struct Outcome {
     pub stats: Stats,
     pub diags: Vec<Diag>,
     pub build_project: Option<PathBuf>,
+    /*
+    Which module requires which, for the whole project analyses in `check`.
+
+    The graph is complete when the cache is off, which holds for every read
+    only run: the cache applies only to writes.
+    */
+    pub graph: crate::requires::graph::Graph,
 }
 
 impl Outcome {
@@ -162,6 +169,7 @@ pub fn run(root: &Path, config: &Config, write: bool) -> Result<Outcome> {
 
     // --- Parallel per file processing ---------------------------------------
     let shared_diags = Mutex::new(diags);
+    let shared_graph = Mutex::new(crate::requires::graph::Graph::default());
     let stats = Mutex::new(Stats::default());
 
     let fresh_hashes: Mutex<Vec<(String, u64)>> = Mutex::new(Vec::new());
@@ -238,6 +246,8 @@ pub fn run(root: &Path, config: &Config, write: bool) -> Result<Outcome> {
             }
         }
 
+        let owns = pool.owns_requires(front);
+
         let mut local_diags = Vec::new();
         let rewritten = process_file(
             path,
@@ -249,7 +259,7 @@ pub fn run(root: &Path, config: &Config, write: bool) -> Result<Outcome> {
             &config.rules,
             write,
             &pool,
-            pool.owns_requires(front),
+            owns,
             &mut local_diags,
         );
         let mut s = stats.lock().unwrap();
@@ -262,6 +272,32 @@ pub fn run(root: &Path, config: &Config, write: bool) -> Result<Outcome> {
         }
 
         drop(s);
+
+        /*
+        The serial half of section 4.4. Every worker collects its own edges
+        with no lock, and this merge is the one place they meet. So the graph
+        builds once at the end of each file, and no worker contends on a
+        require. An init file keys on its directory, so the edge into a
+        directory module meets the edges out of its init file on one node.
+        */
+        {
+            let node = crate::requires::graph::node_of(path);
+            let mut g = shared_graph.lock().unwrap();
+
+            if owns {
+                g.see(node);
+            } else {
+                // A worm resolves the requires of this file, so the graph
+                // holds no edges for it. The unused analysis checks the mark.
+                g.see_opaque(node);
+            }
+
+            if let Some(file) = &rewritten {
+                for to in &file.required {
+                    g.add(node, to);
+                }
+            }
+        }
         // Only a clean file gets a cache entry; errors must appear again.
         if rewritten.is_some()
             && !local_diags
@@ -387,5 +423,6 @@ pub fn run(root: &Path, config: &Config, write: bool) -> Result<Outcome> {
         stats,
         diags,
         build_project,
+        graph: shared_graph.into_inner().unwrap(),
     })
 }

--- a/crates/larvae/src/requires/analyse.rs
+++ b/crates/larvae/src/requires/analyse.rs
@@ -1,0 +1,475 @@
+/*!
+The whole project questions that `check` answers, as diagnostics.
+
+This module is separate from [`graph`](crate::requires::graph), which knows
+edges and nothing about larvae: the graph answers "is there a cycle", and
+this module decides whether the project wants a report, what the message
+calls the modules, and whether the finding fails the run. The linter has the
+same split: a lint finds, and the host sets the level.
+*/
+
+use std::path::{Path, PathBuf};
+
+use crate::config::check::CheckConfig;
+use crate::diag::{Diag, Severity};
+use crate::lint::Level;
+use crate::requires::datamodel::{ScriptKind, script_kind};
+use crate::requires::graph::{Graph, node_of};
+
+/// Run every enabled whole project check and return the findings
+pub fn run(
+    graph: &Graph,
+    cfg: &CheckConfig,
+    requires: &crate::config::RequiresConfig,
+    root: &Path,
+) -> Vec<Diag> {
+    let mut out = Vec::new();
+
+    cycles(graph, cfg, &mut out);
+    unused(graph, cfg, root, &mut out);
+    early_require(graph, cfg, requires, &mut out);
+
+    out
+}
+
+/*
+Client scripts that require through an indexing style that does not wait.
+
+The race exists only for the `roblox-instance` target, because the other two
+targets emit no indexing. And it exists only on the client: a server script
+runs after the DataModel is built, while a LocalScript can start before its
+modules have replicated.
+
+One diagnostic per file. The fix is one config line, so a diagnostic per
+require site would repeat the same advice.
+*/
+fn early_require(
+    graph: &Graph,
+    cfg: &CheckConfig,
+    requires: &crate::config::RequiresConfig,
+    out: &mut Vec<Diag>,
+) {
+    use crate::config::{IndexingStyle, Target};
+
+    let Some(severity) = severity(cfg.early_require) else {
+        return;
+    };
+
+    if requires.target != Target::RobloxInstance {
+        return;
+    }
+
+    let style = requires.indexing_style.unwrap_or_default();
+
+    if style == IndexingStyle::WaitForChild {
+        return;
+    }
+
+    for node in graph.nodes() {
+        let name = node.file_name().and_then(|s| s.to_str()).unwrap_or("");
+
+        if script_kind(name) != ScriptKind::Client || graph.requires_of(node).is_empty() {
+            continue;
+        }
+
+        out.push(Diag {
+            severity,
+            file: node.to_path_buf(),
+            line_col: None,
+            message: "this client script requires without waiting for replication".to_string(),
+            help: Some(
+                "a LocalScript can run before what it needs has replicated, set [requires] indexing_style = \"wait_for_child\""
+                    .to_string(),
+            ),
+        });
+    }
+}
+
+fn severity(level: Level) -> Option<Severity> {
+    match level {
+        Level::Allow => None,
+
+        Level::Warn => Some(Severity::Warning),
+
+        Level::Deny => Some(Severity::Error),
+    }
+}
+
+/*
+One diagnostic per cycle, reported against its lowest member.
+
+The message names the whole cycle, not one edge of it. To break a cycle, the
+reader chooses which dependency to invert, and that choice needs the full
+loop in view. A report of `a requires b` for a tangle of four modules points
+at the wrong file.
+*/
+fn cycles(graph: &Graph, cfg: &CheckConfig, out: &mut Vec<Diag>) {
+    let Some(severity) = severity(cfg.cycles) else {
+        return;
+    };
+
+    for cycle in graph.cycles() {
+        let Some(first) = cycle.first() else {
+            continue;
+        };
+
+        let names: Vec<String> = cycle.iter().map(|p| crate::ui::rel(p)).collect();
+
+        let message = match cycle.len() {
+            1 => format!("{} requires itself", names[0]),
+
+            _ => format!("these {} modules require each other", cycle.len()),
+        };
+
+        out.push(Diag {
+            severity,
+            file: first.clone(),
+            line_col: None,
+            message,
+            help: Some(format!(
+                "the cycle is {}, break it by moving the shared part out or requiring lazily inside a function",
+                names.join(" -> ")
+            )),
+        });
+    }
+}
+
+/*
+Modules that nothing requires.
+
+A Script or a LocalScript is never reported: Roblox runs those, it does not
+require them, so no incoming edge is normal for them. That rule covers most
+of a project with no configuration, and `[check] entries` covers a module
+that starts some other way.
+
+When a worm owns the requires of a file, the graph has no edges for that
+file, and the file can require any module. Then "nothing requires this" is a
+guess for every module, so the analysis reports nothing.
+*/
+fn unused(graph: &Graph, cfg: &CheckConfig, root: &Path, out: &mut Vec<Diag>) {
+    let Some(severity) = severity(cfg.unused_modules) else {
+        return;
+    };
+
+    if graph.has_opaque() {
+        return;
+    }
+
+    let configured: Vec<PathBuf> = cfg
+        .entries
+        .iter()
+        .map(|e| {
+            let joined = root.join(e);
+
+            node_of(&joined).to_path_buf()
+        })
+        .collect();
+
+    for module in graph.unused(&configured) {
+        if !is_module_script(&module) {
+            continue;
+        }
+
+        out.push(Diag {
+            severity,
+            file: module.clone(),
+            line_col: None,
+            message: "nothing requires this module".to_string(),
+            help: Some(
+                "delete it, or list it under [check] entries if something runs it another way"
+                    .to_string(),
+            ),
+        });
+    }
+}
+
+/// True when Roblox would require this file, not run it
+fn is_module_script(path: &Path) -> bool {
+    let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+
+    script_kind(name) == ScriptKind::Module
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graph_of(edges: &[(&str, &str)], extra: &[&str]) -> Graph {
+        let mut g = Graph::default();
+
+        for (from, to) in edges {
+            g.add(Path::new(from), Path::new(to));
+        }
+
+        for node in extra {
+            g.see(Path::new(node));
+        }
+
+        g
+    }
+
+    fn found(graph: &Graph, cfg: &CheckConfig) -> Vec<Diag> {
+        run(
+            graph,
+            cfg,
+            &crate::config::RequiresConfig::default(),
+            Path::new("/project"),
+        )
+    }
+
+    /// The instance target with a style that does not wait, which is the race
+    fn racing() -> crate::config::RequiresConfig {
+        crate::config::RequiresConfig {
+            target: crate::config::Target::RobloxInstance,
+            indexing_style: Some(crate::config::IndexingStyle::FindFirstChild),
+            ..Default::default()
+        }
+    }
+
+    fn found_with(
+        graph: &Graph,
+        cfg: &CheckConfig,
+        requires: &crate::config::RequiresConfig,
+    ) -> Vec<Diag> {
+        run(graph, cfg, requires, Path::new("/project"))
+    }
+
+    fn denying() -> CheckConfig {
+        CheckConfig {
+            cycles: Level::Deny,
+            unused_modules: Level::Deny,
+            ..Default::default()
+        }
+    }
+
+    // --- cycles ------------------------------------------------------------
+
+    #[test]
+    fn a_cycle_is_reported_once_naming_every_member() {
+        let g = graph_of(&[("a.luau", "b.luau"), ("b.luau", "a.luau")], &[]);
+        let diags = found(&g, &CheckConfig::default());
+
+        assert_eq!(diags.len(), 1);
+        assert!(
+            diags[0].message.contains("2 modules"),
+            "{}",
+            diags[0].message
+        );
+
+        let help = diags[0].help.as_deref().unwrap_or("");
+
+        assert!(help.contains("a.luau") && help.contains("b.luau"), "{help}");
+    }
+
+    #[test]
+    fn a_module_requiring_itself_says_so_plainly() {
+        let g = graph_of(&[("a.luau", "a.luau")], &[]);
+        let diags = found(&g, &CheckConfig::default());
+
+        assert!(
+            diags[0].message.contains("requires itself"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn cycles_warn_by_default_and_deny_when_asked() {
+        let g = graph_of(&[("a.luau", "b.luau"), ("b.luau", "a.luau")], &[]);
+
+        assert_eq!(
+            found(&g, &CheckConfig::default())[0].severity,
+            Severity::Warning
+        );
+        assert_eq!(found(&g, &denying())[0].severity, Severity::Error);
+    }
+
+    #[test]
+    fn a_project_can_turn_cycles_off() {
+        let g = graph_of(&[("a.luau", "b.luau"), ("b.luau", "a.luau")], &[]);
+        let cfg = CheckConfig {
+            cycles: Level::Allow,
+            ..Default::default()
+        };
+
+        assert!(found(&g, &cfg).is_empty());
+    }
+
+    #[test]
+    fn an_acyclic_project_reports_nothing() {
+        let g = graph_of(&[("a.luau", "b.luau")], &[]);
+        let cfg = CheckConfig {
+            cycles: Level::Warn,
+            ..Default::default()
+        };
+
+        assert!(found(&g, &cfg).is_empty());
+    }
+
+    // --- unused -------------------------------------------------------------
+
+    #[test]
+    fn unused_modules_are_quiet_until_a_project_asks() {
+        let g = graph_of(&[("a.luau", "b.luau")], &["orphan.luau"]);
+
+        assert!(found(&g, &CheckConfig::default()).is_empty());
+    }
+
+    #[test]
+    fn a_module_nothing_requires_is_reported_when_asked() {
+        let g = graph_of(&[("main.server.luau", "b.luau")], &["orphan.luau"]);
+        let diags = found(&g, &denying());
+
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].file.ends_with("orphan.luau"));
+    }
+
+    /// Roblox runs these rather than requiring them, so no incoming edge is normal
+    #[test]
+    fn a_script_or_localscript_is_never_an_unused_module() {
+        let g = graph_of(&[], &["boot.server.luau", "ui.client.luau"]);
+
+        assert!(found(&g, &denying()).is_empty());
+    }
+
+    #[test]
+    fn a_configured_entry_is_not_unused() {
+        let g = graph_of(&[], &["/project/src/boot.luau"]);
+        let cfg = CheckConfig {
+            unused_modules: Level::Deny,
+            entries: vec![PathBuf::from("src/boot.luau")],
+            ..Default::default()
+        };
+
+        assert!(found(&g, &cfg).is_empty());
+    }
+
+    /// The entry names the init file, and the graph keys the module on its directory
+    #[test]
+    fn an_entry_written_as_an_init_file_matches_the_directory_node() {
+        let g = graph_of(&[], &["/project/src/pkg"]);
+        let cfg = CheckConfig {
+            unused_modules: Level::Deny,
+            entries: vec![PathBuf::from("src/pkg/init.luau")],
+            ..Default::default()
+        };
+
+        assert!(found(&g, &cfg).is_empty());
+    }
+
+    #[test]
+    fn a_required_module_is_not_unused() {
+        let g = graph_of(&[("main.server.luau", "helper.luau")], &[]);
+
+        assert!(found(&g, &denying()).is_empty());
+    }
+
+    /// The graph misses the edges of a worm owned file, so a report is a guess
+    #[test]
+    fn a_worm_owned_file_silences_the_unused_analysis() {
+        let mut g = graph_of(&[], &["orphan.luau"]);
+        g.see_opaque(Path::new("styled.luau"));
+
+        assert!(found(&g, &denying()).is_empty());
+    }
+
+    /// A missing edge can hide a cycle, but it cannot invent one
+    #[test]
+    fn a_worm_owned_file_does_not_silence_the_cycle_analysis() {
+        let mut g = graph_of(&[("a.luau", "b.luau"), ("b.luau", "a.luau")], &[]);
+        g.see_opaque(Path::new("styled.luau"));
+
+        assert_eq!(found(&g, &denying()).len(), 1);
+    }
+
+    /// Both checks run, and a project with both problems hears about both
+    #[test]
+    fn the_two_checks_are_independent() {
+        let g = graph_of(
+            &[("a.luau", "b.luau"), ("b.luau", "a.luau")],
+            &["orphan.luau"],
+        );
+        let diags = found(&g, &denying());
+
+        assert_eq!(diags.len(), 2, "{diags:?}");
+    }
+
+    // --- early require -------------------------------------------------------
+
+    fn client_project() -> Graph {
+        let mut g = Graph::default();
+        g.add(Path::new("ui.client.luau"), Path::new("helper.luau"));
+
+        g
+    }
+
+    #[test]
+    fn a_client_script_requiring_without_waiting_is_reported() {
+        let diags = found_with(&client_project(), &CheckConfig::default(), &racing());
+
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(diags[0].file.ends_with("ui.client.luau"));
+        assert!(
+            diags[0]
+                .help
+                .as_deref()
+                .unwrap_or("")
+                .contains("wait_for_child")
+        );
+    }
+
+    #[test]
+    fn wait_for_child_closes_the_race_and_says_nothing() {
+        let requires = crate::config::RequiresConfig {
+            indexing_style: Some(crate::config::IndexingStyle::WaitForChild),
+            ..racing()
+        };
+
+        assert!(found_with(&client_project(), &CheckConfig::default(), &requires).is_empty());
+    }
+
+    /// The other targets emit no indexing, so there is nothing to race on
+    #[test]
+    fn the_string_target_is_never_reported() {
+        let requires = crate::config::RequiresConfig::default();
+
+        assert!(found_with(&client_project(), &CheckConfig::default(), &requires).is_empty());
+    }
+
+    /// A server script runs after the DataModel is built
+    #[test]
+    fn a_server_script_is_not_racing_replication() {
+        let mut g = Graph::default();
+        g.add(Path::new("boot.server.luau"), Path::new("helper.luau"));
+
+        assert!(found_with(&g, &CheckConfig::default(), &racing()).is_empty());
+    }
+
+    #[test]
+    fn a_client_script_that_requires_nothing_is_not_reported() {
+        let mut g = Graph::default();
+        g.see(Path::new("ui.client.luau"));
+
+        assert!(found_with(&g, &CheckConfig::default(), &racing()).is_empty());
+    }
+
+    #[test]
+    fn it_is_one_diagnostic_per_file_rather_than_per_require() {
+        let mut g = Graph::default();
+        g.add(Path::new("ui.client.luau"), Path::new("a.luau"));
+        g.add(Path::new("ui.client.luau"), Path::new("b.luau"));
+        g.add(Path::new("ui.client.luau"), Path::new("c.luau"));
+
+        assert_eq!(found_with(&g, &CheckConfig::default(), &racing()).len(), 1);
+    }
+
+    #[test]
+    fn a_project_can_turn_it_off() {
+        let cfg = CheckConfig {
+            early_require: Level::Allow,
+            ..Default::default()
+        };
+
+        assert!(found_with(&client_project(), &cfg, &racing()).is_empty());
+    }
+}

--- a/crates/larvae/src/requires/graph.rs
+++ b/crates/larvae/src/requires/graph.rs
@@ -1,0 +1,532 @@
+/*!
+The require graph: which module requires which, and the answers that gives.
+
+`check` answers three whole project questions, and no single file can answer
+them: a cycle is a property of the whole graph, an unused module is a module
+with no incoming edge, and a bundle initialisation order is a topological
+sort. So resolution collects the edges while it walks every require, and the
+analyses run once at the end.
+
+The edges are filesystem paths, not DataModel paths, on purpose. Two requires
+can spell one module differently: `./sibling` from one file, and
+`@game/ReplicatedStorage/app/sibling` from another. Both resolve to the same
+file, so both are one node here. A graph keyed on the written form would
+count that module as two nodes, and would find no cycle and no reuse.
+
+Collection is per file and lock free, as section 4.4 asks: every worker
+fills its own edge list, and the merge is one serial pass at the end.
+*/
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+/*
+The graph node for a file on disk.
+
+A require of a directory module resolves to the directory, not to the init
+file inside it. So the node for `foo/init.luau` is `foo`, and the edge into
+the directory meets the edges out of the init file on one node. Only a plain
+`init.luau` or `init.lua` forms a directory module, so only those two names
+map to the parent.
+*/
+pub fn node_of(path: &Path) -> &Path {
+    let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+
+    if name == "init.luau" || name == "init.lua" {
+        return path.parent().unwrap_or(path);
+    }
+
+    path
+}
+
+/// Every require that resolved to a module, as file to file edges
+#[derive(Debug, Default, Clone)]
+pub struct Graph {
+    /// The modules each module requires, in the order the requires appear
+    edges: BTreeMap<PathBuf, Vec<PathBuf>>,
+    /// Every module the walk saw, including leaves that nothing requires
+    nodes: BTreeSet<PathBuf>,
+    /// The files whose requires the walk does not see; a worm resolves them
+    opaque: BTreeSet<PathBuf>,
+}
+
+impl Graph {
+    /// Record that `from` requires `to`
+    pub fn add(&mut self, from: &Path, to: &Path) {
+        self.nodes.insert(from.to_path_buf());
+        self.nodes.insert(to.to_path_buf());
+
+        let out = self.edges.entry(from.to_path_buf()).or_default();
+
+        // The same module required twice is one edge. So a cycle is reported
+        // once, not once for each require site.
+        if !out.iter().any(|p| p == to) {
+            out.push(to.to_path_buf());
+        }
+    }
+
+    /// Record a file from the walk, with or without requires
+    pub fn see(&mut self, file: &Path) {
+        self.nodes.insert(file.to_path_buf());
+    }
+
+    /*
+    Record a file whose requires larvae does not see.
+
+    A worm that owns its requires resolves them itself, so the walk collects
+    no edges for the file. The file is still a node. The unused analysis
+    checks for this mark, because a node with an unknown edge list makes
+    "nothing requires this" a guess.
+    */
+    pub fn see_opaque(&mut self, file: &Path) {
+        self.nodes.insert(file.to_path_buf());
+        self.opaque.insert(file.to_path_buf());
+    }
+
+    /// True when a node with an unknown edge list exists
+    pub fn has_opaque(&self) -> bool {
+        !self.opaque.is_empty()
+    }
+
+    /// Fold the edges of another worker in; this is the serial half of section 4.4
+    pub fn merge(&mut self, other: Graph) {
+        for node in other.nodes {
+            self.nodes.insert(node);
+        }
+
+        for node in other.opaque {
+            self.opaque.insert(node);
+        }
+
+        for (from, tos) in other.edges {
+            let out = self.edges.entry(from).or_default();
+
+            for to in tos {
+                if !out.contains(&to) {
+                    out.push(to);
+                }
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    pub fn nodes(&self) -> impl Iterator<Item = &Path> {
+        self.nodes.iter().map(PathBuf::as_path)
+    }
+
+    pub fn requires_of(&self, file: &Path) -> &[PathBuf] {
+        self.edges.get(file).map_or(&[], Vec::as_slice)
+    }
+
+    /*
+    Every cycle, each reported once and sorted from its lowest member.
+
+    This uses Tarjan's strongly connected components, not a search for back
+    edges. A back edge finds one cycle. A strongly connected component finds
+    the full set of modules that reach each other, which is the set a reader
+    must break and a bundler must condense. A report of `a -> b -> a` for a
+    tangle of three modules points at the wrong file.
+
+    A component of one module is a cycle only when the module requires
+    itself.
+    */
+    pub fn cycles(&self) -> Vec<Vec<PathBuf>> {
+        let mut state = Tarjan {
+            graph: self,
+            index: BTreeMap::new(),
+            low: BTreeMap::new(),
+            on_stack: BTreeSet::new(),
+            stack: Vec::new(),
+            next: 0,
+            out: Vec::new(),
+        };
+
+        for node in &self.nodes {
+            if !state.index.contains_key(node) {
+                state.walk(node);
+            }
+        }
+
+        for cycle in &mut state.out {
+            cycle.sort();
+        }
+
+        state.out.sort();
+
+        state.out
+    }
+
+    /*
+    The modules with no incoming edge that are not entry points.
+
+    An entry point is a module the project runs directly, and the graph
+    alone cannot know one: a `Script` under `ServerScriptService` has no
+    incoming edge and is the whole program. So the caller passes the entry
+    points it knows, and every other module with no incoming edge is a
+    finding.
+    */
+    pub fn unused(&self, entries: &[PathBuf]) -> Vec<PathBuf> {
+        let mut required: BTreeSet<&Path> = BTreeSet::new();
+
+        for tos in self.edges.values() {
+            for to in tos {
+                required.insert(to.as_path());
+            }
+        }
+
+        self.nodes
+            .iter()
+            .filter(|n| !required.contains(n.as_path()))
+            .filter(|n| !entries.iter().any(|e| e == *n))
+            .cloned()
+            .collect()
+    }
+
+    /*
+    The modules in an order a bundle can initialise them, dependencies first.
+
+    The result is `None` when the graph has a cycle, because no such order
+    exists. An invented order makes a bundler emit code that reads a nil
+    field at startup. A caller that wants an order anyway condenses the
+    cycles first.
+    */
+    pub fn topological(&self) -> Option<Vec<PathBuf>> {
+        if !self.cycles().is_empty() {
+            return None;
+        }
+
+        let mut seen: BTreeSet<&Path> = BTreeSet::new();
+        let mut out = Vec::with_capacity(self.nodes.len());
+
+        for node in &self.nodes {
+            self.emit_after_deps(node, &mut seen, &mut out);
+        }
+
+        Some(out)
+    }
+
+    fn emit_after_deps<'g>(
+        &'g self,
+        node: &'g Path,
+        seen: &mut BTreeSet<&'g Path>,
+        out: &mut Vec<PathBuf>,
+    ) {
+        if !seen.insert(node) {
+            return;
+        }
+
+        for to in self.requires_of(node) {
+            self.emit_after_deps(to, seen, out);
+        }
+
+        out.push(node.to_path_buf());
+    }
+}
+
+/// Tarjan's SCC state, in its own struct so the recursion carries one borrow
+struct Tarjan<'g> {
+    graph: &'g Graph,
+    index: BTreeMap<PathBuf, u32>,
+    low: BTreeMap<PathBuf, u32>,
+    on_stack: BTreeSet<PathBuf>,
+    stack: Vec<PathBuf>,
+    next: u32,
+    out: Vec<Vec<PathBuf>>,
+}
+
+impl Tarjan<'_> {
+    fn walk(&mut self, node: &Path) {
+        let key = node.to_path_buf();
+
+        self.index.insert(key.clone(), self.next);
+        self.low.insert(key.clone(), self.next);
+        self.next += 1;
+        self.stack.push(key.clone());
+        self.on_stack.insert(key.clone());
+
+        for to in self.graph.requires_of(node) {
+            if !self.index.contains_key(to) {
+                self.walk(to);
+
+                let child = self.low[to];
+                let mine = self.low[&key];
+                self.low.insert(key.clone(), mine.min(child));
+            } else if self.on_stack.contains(to) {
+                let child = self.index[to];
+                let mine = self.low[&key];
+                self.low.insert(key.clone(), mine.min(child));
+            }
+        }
+
+        if self.low[&key] != self.index[&key] {
+            return;
+        }
+
+        let mut component = Vec::new();
+
+        while let Some(top) = self.stack.pop() {
+            self.on_stack.remove(&top);
+            let last = top == key;
+            component.push(top);
+
+            if last {
+                break;
+            }
+        }
+
+        /*
+        One module is a cycle only when it requires itself. Every other
+        component of one module is an ordinary module, and a report of those
+        would name the whole project.
+        */
+        let self_edge = component.len() == 1
+            && self
+                .graph
+                .requires_of(&component[0])
+                .iter()
+                .any(|to| *to == component[0]);
+
+        if component.len() > 1 || self_edge {
+            self.out.push(component);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    fn graph(edges: &[(&str, &str)]) -> Graph {
+        let mut g = Graph::default();
+
+        for (from, to) in edges {
+            g.add(Path::new(from), Path::new(to));
+        }
+
+        g
+    }
+
+    #[test]
+    fn an_edge_records_both_ends_as_nodes() {
+        let g = graph(&[("a", "b")]);
+
+        assert_eq!(
+            g.nodes().collect::<Vec<_>>(),
+            [Path::new("a"), Path::new("b")]
+        );
+        assert_eq!(g.requires_of(Path::new("a")), [p("b")]);
+        assert!(g.requires_of(Path::new("b")).is_empty());
+    }
+
+    /// Two requires of one module are one edge, or a cycle reports twice
+    #[test]
+    fn the_same_edge_twice_is_recorded_once() {
+        let g = graph(&[("a", "b"), ("a", "b")]);
+
+        assert_eq!(g.requires_of(Path::new("a")).len(), 1);
+    }
+
+    #[test]
+    fn a_file_with_no_requires_is_still_a_node() {
+        let mut g = Graph::default();
+        g.see(Path::new("lonely"));
+
+        assert_eq!(g.nodes().count(), 1);
+    }
+
+    #[test]
+    fn merging_keeps_every_node_and_edge_once() {
+        let mut a = graph(&[("x", "y")]);
+        a.merge(graph(&[("x", "y"), ("y", "z")]));
+
+        assert_eq!(a.requires_of(Path::new("x")), [p("y")]);
+        assert_eq!(a.requires_of(Path::new("y")), [p("z")]);
+        assert_eq!(a.nodes().count(), 3);
+    }
+
+    // --- the node key -------------------------------------------------------
+
+    #[test]
+    fn an_init_file_keys_on_its_directory() {
+        assert_eq!(
+            node_of(Path::new("/p/src/pkg/init.luau")),
+            Path::new("/p/src/pkg")
+        );
+        assert_eq!(
+            node_of(Path::new("/p/src/pkg/init.lua")),
+            Path::new("/p/src/pkg")
+        );
+    }
+
+    /// Only a plain init file forms a directory module
+    #[test]
+    fn other_files_key_on_themselves() {
+        assert_eq!(
+            node_of(Path::new("/p/src/a.luau")),
+            Path::new("/p/src/a.luau")
+        );
+        assert_eq!(
+            node_of(Path::new("/p/src/init.client.luau")),
+            Path::new("/p/src/init.client.luau")
+        );
+    }
+
+    // --- opaque files -------------------------------------------------------
+
+    #[test]
+    fn an_opaque_file_is_a_node_and_marks_the_graph() {
+        let mut g = Graph::default();
+        g.see_opaque(Path::new("styled.luau"));
+
+        assert!(g.has_opaque());
+        assert_eq!(g.nodes().count(), 1);
+    }
+
+    #[test]
+    fn merging_carries_the_opaque_mark() {
+        let mut a = Graph::default();
+        let mut b = Graph::default();
+        b.see_opaque(Path::new("styled.luau"));
+        a.merge(b);
+
+        assert!(a.has_opaque());
+    }
+
+    // --- cycles ------------------------------------------------------------
+
+    #[test]
+    fn an_acyclic_graph_has_no_cycles() {
+        assert!(graph(&[("a", "b"), ("b", "c")]).cycles().is_empty());
+    }
+
+    #[test]
+    fn a_two_module_cycle_is_found() {
+        let found = graph(&[("a", "b"), ("b", "a")]).cycles();
+
+        assert_eq!(found, vec![vec![p("a"), p("b")]]);
+    }
+
+    #[test]
+    fn a_longer_cycle_is_reported_as_one_component() {
+        let found = graph(&[("a", "b"), ("b", "c"), ("c", "a")]).cycles();
+
+        assert_eq!(found, vec![vec![p("a"), p("b"), p("c")]]);
+    }
+
+    /// A back edge search would report a two module cycle inside this one
+    #[test]
+    fn a_tangle_is_one_component_rather_than_several_pairs() {
+        let found = graph(&[("a", "b"), ("b", "a"), ("b", "c"), ("c", "b")]).cycles();
+
+        assert_eq!(found, vec![vec![p("a"), p("b"), p("c")]]);
+    }
+
+    #[test]
+    fn a_module_requiring_itself_is_a_cycle() {
+        assert_eq!(graph(&[("a", "a")]).cycles(), vec![vec![p("a")]]);
+    }
+
+    /// Every other component of one is an ordinary module
+    #[test]
+    fn a_plain_module_is_not_reported_as_a_cycle_of_one() {
+        assert!(graph(&[("a", "b")]).cycles().is_empty());
+    }
+
+    #[test]
+    fn two_separate_cycles_are_both_found() {
+        let found = graph(&[("a", "b"), ("b", "a"), ("x", "y"), ("y", "x")]).cycles();
+
+        assert_eq!(found, vec![vec![p("a"), p("b")], vec![p("x"), p("y")]]);
+    }
+
+    /// A diamond is not a cycle, and a naive visited check can call it one
+    #[test]
+    fn a_diamond_is_not_a_cycle() {
+        let found = graph(&[("a", "b"), ("a", "c"), ("b", "d"), ("c", "d")]).cycles();
+
+        assert!(found.is_empty(), "{found:?}");
+    }
+
+    // --- unused ------------------------------------------------------------
+
+    #[test]
+    fn a_module_nothing_requires_is_unused() {
+        let g = graph(&[("a", "b")]);
+
+        assert_eq!(g.unused(&[]), [p("a")]);
+    }
+
+    #[test]
+    fn an_entry_point_is_not_unused() {
+        let g = graph(&[("a", "b")]);
+
+        assert!(g.unused(&[p("a")]).is_empty());
+    }
+
+    #[test]
+    fn an_orphan_with_no_edges_at_all_is_unused() {
+        let mut g = graph(&[("a", "b")]);
+        g.see(Path::new("orphan"));
+
+        assert_eq!(g.unused(&[p("a")]), [p("orphan")]);
+    }
+
+    /// Everything in a cycle has an incoming edge, so nothing there is unused
+    #[test]
+    fn a_cycle_hides_nothing_from_the_unused_check() {
+        let g = graph(&[("a", "b"), ("b", "a")]);
+
+        assert!(g.unused(&[]).is_empty());
+    }
+
+    // --- order -------------------------------------------------------------
+
+    #[test]
+    fn a_topological_order_puts_dependencies_first() {
+        let g = graph(&[("a", "b"), ("b", "c")]);
+        let order = g.topological().expect("acyclic");
+
+        let at = |s: &str| order.iter().position(|p| p == Path::new(s)).unwrap();
+
+        assert!(at("c") < at("b"), "{order:?}");
+        assert!(at("b") < at("a"), "{order:?}");
+    }
+
+    #[test]
+    fn a_diamond_orders_the_shared_dependency_first() {
+        let g = graph(&[("a", "b"), ("a", "c"), ("b", "d"), ("c", "d")]);
+        let order = g.topological().expect("acyclic");
+
+        let at = |s: &str| order.iter().position(|p| p == Path::new(s)).unwrap();
+
+        assert!(at("d") < at("b") && at("d") < at("c"), "{order:?}");
+        assert!(at("b") < at("a") && at("c") < at("a"), "{order:?}");
+    }
+
+    /// No such order exists, and an invented one reads a nil field at startup
+    #[test]
+    fn a_cyclic_graph_has_no_topological_order() {
+        assert!(graph(&[("a", "b"), ("b", "a")]).topological().is_none());
+    }
+
+    #[test]
+    fn every_node_appears_exactly_once_in_the_order() {
+        let g = graph(&[("a", "b"), ("a", "c"), ("b", "d"), ("c", "d")]);
+        let order = g.topological().unwrap();
+
+        assert_eq!(order.len(), 4);
+
+        let mut sorted = order.clone();
+        sorted.sort();
+        sorted.dedup();
+
+        assert_eq!(sorted.len(), order.len());
+    }
+}

--- a/crates/larvae/src/requires/graph.rs
+++ b/crates/larvae/src/requires/graph.rs
@@ -48,6 +48,28 @@ pub struct Graph {
     nodes: BTreeSet<PathBuf>,
     /// The files whose requires the walk does not see; a worm resolves them
     opaque: BTreeSet<PathBuf>,
+    /*
+    Every resolved require site, with the span of its string token.
+
+    Separate from `edges`, because the two answer different questions and
+    need different shapes. An edge is deduplicated, so a cycle is reported
+    once, however many times one module requires another. A site is not
+    deduplicated, because the bundler must rewrite every call, and a pairing
+    of sites against deduplicated edges by position rewrites the wrong call.
+    */
+    sites: BTreeMap<PathBuf, Vec<Site>>,
+}
+
+/// One `require("...")` that resolved, and where its string token sits
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Site {
+    /// The byte offset of the `require` identifier
+    pub at: u32,
+    /// The byte range of the string token, quotes included
+    pub tok_start: u32,
+    pub tok_end: u32,
+    /// The module the require resolved to, in the node form of the graph
+    pub target: PathBuf,
 }
 
 impl Graph {
@@ -63,6 +85,16 @@ impl Graph {
         if !out.iter().any(|p| p == to) {
             out.push(to.to_path_buf());
         }
+    }
+
+    /// Record where a require sits, for anything that must rewrite it
+    pub fn add_site(&mut self, from: &Path, site: Site) {
+        self.sites.entry(from.to_path_buf()).or_default().push(site);
+    }
+
+    /// The resolved require sites of one file, in source order
+    pub fn sites_of(&self, file: &Path) -> &[Site] {
+        self.sites.get(file).map_or(&[], Vec::as_slice)
     }
 
     /// Record a file from the walk, with or without requires
@@ -88,6 +120,11 @@ impl Graph {
         !self.opaque.is_empty()
     }
 
+    /// True when the edge list of this file is unknown
+    pub fn is_opaque(&self, file: &Path) -> bool {
+        self.opaque.contains(file)
+    }
+
     /// Fold the edges of another worker in; this is the serial half of section 4.4
     pub fn merge(&mut self, other: Graph) {
         for node in other.nodes {
@@ -106,6 +143,10 @@ impl Graph {
                     out.push(to);
                 }
             }
+        }
+
+        for (from, sites) in other.sites {
+            self.sites.entry(from).or_default().extend(sites);
         }
     }
 
@@ -378,6 +419,47 @@ mod tests {
         );
     }
 
+    // --- sites --------------------------------------------------------------
+
+    fn site(at: u32, target: &str) -> Site {
+        Site {
+            at,
+            tok_start: at + 8,
+            tok_end: at + 12,
+            target: p(target),
+        }
+    }
+
+    /// Two requires of one module are one edge, but they stay two sites
+    #[test]
+    fn sites_are_not_deduplicated() {
+        let mut g = graph(&[("a", "b"), ("a", "b")]);
+        g.add_site(Path::new("a"), site(0, "b"));
+        g.add_site(Path::new("a"), site(30, "b"));
+
+        assert_eq!(g.requires_of(Path::new("a")).len(), 1);
+        assert_eq!(g.sites_of(Path::new("a")).len(), 2);
+    }
+
+    #[test]
+    fn a_file_without_sites_has_an_empty_list() {
+        let g = graph(&[("a", "b")]);
+
+        assert!(g.sites_of(Path::new("a")).is_empty());
+    }
+
+    #[test]
+    fn merging_keeps_every_site() {
+        let mut a = Graph::default();
+        a.add_site(Path::new("x"), site(0, "y"));
+
+        let mut b = Graph::default();
+        b.add_site(Path::new("x"), site(30, "y"));
+        a.merge(b);
+
+        assert_eq!(a.sites_of(Path::new("x")).len(), 2);
+    }
+
     // --- opaque files -------------------------------------------------------
 
     #[test]
@@ -386,6 +468,8 @@ mod tests {
         g.see_opaque(Path::new("styled.luau"));
 
         assert!(g.has_opaque());
+        assert!(g.is_opaque(Path::new("styled.luau")));
+        assert!(!g.is_opaque(Path::new("other.luau")));
         assert_eq!(g.nodes().count(), 1);
     }
 

--- a/crates/larvae/src/requires/mod.rs
+++ b/crates/larvae/src/requires/mod.rs
@@ -1,4 +1,6 @@
 //! Require resolution and the DataModel mapping
 
+pub mod analyse;
 pub mod datamodel;
+pub mod graph;
 pub mod resolve;

--- a/crates/larvae/src/requires/resolve/emit.rs
+++ b/crates/larvae/src/requires/resolve/emit.rs
@@ -65,6 +65,17 @@ impl<'a> Resolver<'a> {
             }
         };
 
+        /*
+        The edge, recorded at the one place where a require becomes a file.
+
+        Every spelling reaches this point: relative, alias and instance
+        alike. So the graph keys on the resolved module, not on the written
+        form, and two files that name one module add one node.
+        */
+        ctx.required
+            .borrow_mut()
+            .push(node.dm_key_path().to_path_buf());
+
         let out = match ctx.target {
             Target::Path => self.emit_path_target(ctx, &node),
 

--- a/crates/larvae/src/requires/resolve/mod.rs
+++ b/crates/larvae/src/requires/resolve/mod.rs
@@ -51,6 +51,15 @@ pub struct FileCtx<'a> {
     /// The output form for this file; an override can move it off the default
     pub target: Target,
     pub style: IndexingStyle,
+    /*
+    The modules this file resolved a require to, for the require graph.
+
+    The list lives here, not as one more `&mut` beside `diags`, because a
+    worker builds a `FileCtx` per file and shares nothing. So a `RefCell`
+    costs nothing, and every resolver function that can resolve a module
+    already holds the context.
+    */
+    pub required: std::cell::RefCell<Vec<PathBuf>>,
 }
 
 impl<'a> FileCtx<'a> {
@@ -61,6 +70,7 @@ impl<'a> FileCtx<'a> {
 
         Self {
             path,
+            required: std::cell::RefCell::default(),
             dm: mounts.dm_of(path),
             is_init,
             kind: script_kind(file_name),

--- a/crates/larvae/src/rules/mod.rs
+++ b/crates/larvae/src/rules/mod.rs
@@ -109,6 +109,12 @@ const_requires: change `local X = require(...)` to `const X = require(...)`.
 Then single assignment requires get Luau's const treatment. The rule is
 conservative by design. It does not change multi bindings or annotated
 locals.
+
+Luau enforces `const`. A converted name that a later statement reassigns
+turns a file that ran into a syntax error. So the rule resolves the scopes,
+the same walk that the linter and `require_binding` use, and keeps `local`
+on every binding with writes. A file that does not parse gets no conversion,
+because the rule cannot prove that a conversion compiles.
 */
 pub fn const_requires(
     src: &str,
@@ -116,6 +122,8 @@ pub fn const_requires(
     sites: &[RequireSite],
     replacements: &mut Vec<(u32, u32, String)>,
 ) {
+    let mut candidates = Vec::new();
+
     for site in sites {
         let i = site.require_idx;
         // The rule looks backward for the pattern: local <name> = require
@@ -131,6 +139,30 @@ pub fn const_requires(
             && local.kind == TokKind::Ident
             && local.text(src) == "local"
         {
+            // The name token index identifies the binding in the scope walk.
+            candidates.push(((i - 2) as u32, local));
+        }
+    }
+
+    if candidates.is_empty() {
+        return;
+    }
+
+    let Ok(chunk) = crate::syntax::parser::parse(src, toks) else {
+        return;
+    };
+
+    let names = crate::lint::scope::resolve(src, toks, &chunk);
+
+    for (name_idx, local) in candidates {
+        // A later statement reassigns the name, so const would be a syntax error.
+        let reassigned = names
+            .by_token
+            .get(&name_idx)
+            .and_then(|&b| names.bindings.get(b))
+            .is_none_or(|b| !b.writes.is_empty());
+
+        if !reassigned {
             replacements.push((local.start, local.end, "const".to_string()));
         }
     }
@@ -325,6 +357,18 @@ mod tests {
         assert_eq!(apply("x = require(\"./x\")"), "x = require(\"./x\")");
         // A dynamic require has no site.
         assert_eq!(apply("local x = require(p)"), "local x = require(p)");
+    }
+
+    /*
+    Luau enforces const. A conversion of a reassigned name would produce
+    `Variable 'M' is constant and may not be reassigned`, so the rule must
+    keep `local` there.
+    */
+    #[test]
+    fn a_reassigned_require_binding_keeps_local() {
+        let src = "local M = require(\"./m\")\nM = fallback\nreturn M\n";
+
+        assert_eq!(apply(src), src);
     }
 
     #[test]

--- a/crates/larvae/tests/bundle.rs
+++ b/crates/larvae/tests/bundle.rs
@@ -1,0 +1,441 @@
+/*!
+Bundling, checked by running the bundle.
+
+Most tests here execute the output, not only read it. A text assertion
+proves that the bundler produced what was expected, and not that what was
+expected works. larvae already embeds a Luau VM for worms, so a bundle can
+simply run, and that is the only test that can catch a runtime shape being
+wrong: a registry that never populates, a loader that recurses, a module
+that returns the wrong thing.
+*/
+
+use std::path::Path;
+use std::process::Command;
+
+fn bin() -> &'static Path {
+    Path::new(env!("CARGO_BIN_EXE_larvae"))
+}
+
+fn write(root: &Path, name: &str, body: &str) {
+    let path = root.join(name);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, body).unwrap();
+}
+
+/// A project with `files` under `src`, bundled with `args` extra
+fn project(files: &[(&str, &str)], config: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("a temp dir");
+    let root = dir.path();
+
+    write(root, "larvae.toml", config);
+
+    for (name, body) in files {
+        write(root, &format!("src/{name}"), body);
+    }
+
+    dir
+}
+
+fn config_with(bundle: &str) -> String {
+    format!(
+        "[process]\ninput = \"src\"\n\n[requires.mounts]\n\"src\" = \"@game/ReplicatedStorage/app\"\n\n{bundle}"
+    )
+}
+
+fn run_bundle(root: &Path, args: &[&str]) -> Result<String, String> {
+    let output = Command::new(bin())
+        .arg("bundle")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("runs");
+
+    if !output.status.success() {
+        return Err(format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(std::fs::read_to_string(root.join("out.luau")).expect("the bundle was written"))
+}
+
+/// A project with `files` under `src`, bundled from `entry`
+fn bundle(files: &[(&str, &str)], entry: &str) -> Result<String, String> {
+    let dir = project(
+        files,
+        &config_with(&format!(
+            "[bundle]\nentry = \"{entry}\"\noutput = \"out.luau\"\n"
+        )),
+    );
+
+    run_bundle(dir.path(), &[])
+}
+
+/// Execute a bundle and return what its entry returned, as a string
+fn run_luau(source: &str) -> Result<String, String> {
+    let lua = mlua::Lua::new();
+
+    lua.load(source)
+        .eval::<mlua::Value>()
+        .map(|v| match v {
+            mlua::Value::String(s) => s.to_string_lossy().to_string(),
+
+            other => format!("{other:?}"),
+        })
+        .map_err(|e| e.to_string())
+}
+
+#[test]
+fn a_bundled_project_runs_and_returns_what_the_entry_returns() {
+    let text = bundle(
+        &[
+            (
+                "main.luau",
+                "local g = require(\"./greet\")\nreturn g.hello(\"world\")\n",
+            ),
+            (
+                "greet.luau",
+                "return { hello = function(n) return \"hi \" .. n end }\n",
+            ),
+        ],
+        "src/main.luau",
+    )
+    .expect("bundles");
+
+    assert_eq!(run_luau(&text).expect("runs"), "hi world");
+}
+
+#[test]
+fn a_chain_of_modules_all_load() {
+    let text = bundle(
+        &[
+            ("main.luau", "return require(\"./a\")\n"),
+            ("a.luau", "return require(\"./b\") .. \"-a\"\n"),
+            ("b.luau", "return \"b\"\n"),
+        ],
+        "src/main.luau",
+    )
+    .expect("bundles");
+
+    assert_eq!(run_luau(&text).expect("runs"), "b-a");
+}
+
+/// One module required from two places must initialise once, not twice
+#[test]
+fn a_shared_module_is_initialised_exactly_once() {
+    let text = bundle(
+        &[
+            (
+                "main.luau",
+                "require(\"./a\")\nrequire(\"./b\")\nreturn require(\"./tracker\").get()\n",
+            ),
+            ("a.luau", "require(\"./once\")\nreturn {}\n"),
+            ("b.luau", "require(\"./once\")\nreturn {}\n"),
+            // The side effect sits at module level, so it happens per initialisation.
+            ("once.luau", "require(\"./tracker\").bump()\nreturn {}\n"),
+            (
+                "tracker.luau",
+                "local n = 0\nreturn { bump = function() n = n + 1 end, get = function() return tostring(n) end }\n",
+            ),
+        ],
+        "src/main.luau",
+    )
+    .expect("bundles");
+
+    assert_eq!(
+        run_luau(&text).expect("runs"),
+        "1",
+        "the shared module ran more than once"
+    );
+}
+
+/// A module that returns nil is not the same as one that has not run
+#[test]
+fn a_module_returning_nil_is_still_cached() {
+    let text = bundle(
+        &[
+            (
+                "main.luau",
+                "require(\"./side\")\nrequire(\"./side\")\nreturn require(\"./side_count\").n()\n",
+            ),
+            ("side.luau", "require(\"./side_count\").bump()\nreturn nil\n"),
+            (
+                "side_count.luau",
+                "local c = 0\nreturn { bump = function() c = c + 1 end, n = function() return tostring(c) end }\n",
+            ),
+        ],
+        "src/main.luau",
+    )
+    .expect("bundles");
+
+    assert_eq!(run_luau(&text).expect("runs"), "1", "it ran more than once");
+}
+
+/// Matches unbundled Roblox, which raises on a recursive require
+#[test]
+fn a_load_time_cycle_errors_naming_the_module() {
+    let text = bundle(
+        &[
+            ("main.luau", "return require(\"./a\")\n"),
+            ("a.luau", "return require(\"./b\")\n"),
+            ("b.luau", "return require(\"./a\")\n"),
+        ],
+        "src/main.luau",
+    )
+    .expect("bundles");
+
+    let err = run_luau(&text).expect_err("a load time cycle cannot work");
+
+    assert!(err.contains("cyclic require"), "{err}");
+    assert!(err.contains("src/a"), "{err}");
+}
+
+/*
+The pattern that looks cyclic and is not.
+
+A require inside a function defers past load, so both modules finish and the
+call works. This is the common shape in Roblox code, and the reason `check`
+reports cycles as a warning and not an error.
+*/
+#[test]
+fn a_cycle_deferred_into_a_function_still_works() {
+    let text = bundle(
+        &[
+            ("main.luau", "return require(\"./a\").ask()\n"),
+            (
+                "a.luau",
+                "local m = {}\nfunction m.ask() return require(\"./b\").answer() end\nfunction m.name() return \"a\" end\nreturn m\n",
+            ),
+            (
+                "b.luau",
+                "local m = {}\nfunction m.answer() return require(\"./a\").name() .. \"-b\" end\nreturn m\n",
+            ),
+        ],
+        "src/main.luau",
+    )
+    .expect("bundles");
+
+    assert_eq!(run_luau(&text).expect("runs"), "a-b");
+}
+
+#[test]
+fn an_unreachable_module_is_left_out_of_the_bundle() {
+    let text = bundle(
+        &[
+            ("main.luau", "return \"only me\"\n"),
+            ("orphan.luau", "return error(\"this must never run\")\n"),
+        ],
+        "src/main.luau",
+    )
+    .expect("bundles");
+
+    assert!(!text.contains("must never run"), "the orphan was bundled");
+    assert_eq!(run_luau(&text).expect("runs"), "only me");
+}
+
+/*
+The registry finds a module by id at run time, so a module that only a
+dynamic require reaches works when the bundle keeps it. `tree_shake = false`
+is how a project keeps it.
+*/
+#[test]
+fn tree_shaking_off_keeps_the_unreachable_module() {
+    let dir = project(
+        &[
+            ("main.luau", "return \"still me\"\n"),
+            ("kept.luau", "return \"kept text marker\"\n"),
+        ],
+        &config_with(
+            "[bundle]\nentry = \"src/main.luau\"\noutput = \"out.luau\"\ntree_shake = false\n",
+        ),
+    );
+
+    let text = run_bundle(dir.path(), &[]).expect("bundles");
+
+    assert!(text.contains("kept text marker"), "{text}");
+    assert_eq!(run_luau(&text).expect("runs"), "still me");
+}
+
+/// A require of a directory resolves to its init file, on one node
+#[test]
+fn a_directory_module_initialises_through_its_init_file() {
+    let text = bundle(
+        &[
+            ("main.luau", "return require(\"./pkg\")\n"),
+            (
+                "pkg/init.luau",
+                "return require(\"./pkg/helper\") .. \" from pkg\"\n",
+            ),
+            ("pkg/helper.luau", "return \"hi\"\n"),
+        ],
+        "src/main.luau",
+    )
+    .expect("bundles");
+
+    assert_eq!(run_luau(&text).expect("runs"), "hi from pkg");
+}
+
+/// The command line beats the config, like every other command
+#[test]
+fn the_entry_flag_beats_the_configured_entry() {
+    let dir = project(
+        &[
+            ("main.luau", "return \"from the config entry\"\n"),
+            ("other.luau", "return \"from the flag entry\"\n"),
+        ],
+        &config_with("[bundle]\nentry = \"src/main.luau\"\noutput = \"out.luau\"\n"),
+    );
+
+    let text = run_bundle(dir.path(), &["--entry", "src/other.luau"]).expect("bundles");
+
+    assert_eq!(run_luau(&text).expect("runs"), "from the flag entry");
+}
+
+/// Requiring one module twice from one file must rewrite both calls
+#[test]
+fn the_same_module_required_twice_in_a_file_works() {
+    let text = bundle(
+        &[
+            (
+                "main.luau",
+                "local a = require(\"./v\")\nlocal b = require(\"./v\")\nreturn a.s .. b.s\n",
+            ),
+            ("v.luau", "return { s = \"x\" }\n"),
+        ],
+        "src/main.luau",
+    )
+    .expect("bundles");
+
+    assert!(
+        !text.contains("require(\"./v\")"),
+        "a call was left unrewritten"
+    );
+    assert_eq!(run_luau(&text).expect("runs"), "xx");
+}
+
+#[test]
+fn the_bundle_is_byte_identical_across_runs() {
+    let files = [
+        ("main.luau", "return require(\"./a\")\n"),
+        ("a.luau", "return require(\"./b\")\n"),
+        ("b.luau", "return \"b\"\n"),
+    ];
+
+    let once = bundle(&files, "src/main.luau").expect("bundles");
+    let twice = bundle(&files, "src/main.luau").expect("bundles");
+
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn a_missing_entry_is_reported_rather_than_producing_an_empty_bundle() {
+    let err = bundle(&[("main.luau", "return 1\n")], "src/nope.luau")
+        .expect_err("there is no such entry");
+
+    assert!(err.contains("nope.luau"), "{err}");
+}
+
+/*
+A worm-claimed file must bundle as the Luau its worm compiles, and not as
+the raw claimed source.
+
+The front-end runs inside the pipeline, so the file on disk holds markup the
+whole time. A bundler that reads sources from disk ships that markup. The
+worm is a real native worm in a few lines of python, like the one in
+worm_fmt_lint.rs, so the test needs unix.
+*/
+#[cfg(unix)]
+mod worm_frontend {
+    use super::*;
+
+    fn install_worm(root: &Path) {
+        write(
+            root,
+            "mywormdir/worm.toml",
+            r#"
+name  = "markup"
+api   = 1
+form  = "native"
+entry = "worm.py"
+
+[frontend]
+claims = [".luaux"]
+"#,
+        );
+
+        write(
+            root,
+            "mywormdir/worm.py",
+            r#"#!/usr/bin/env python3
+import sys, json, struct
+
+def read():
+    n = sys.stdin.buffer.read(4)
+    if len(n) < 4: sys.exit(0)
+    return json.loads(sys.stdin.buffer.read(struct.unpack("<I", n)[0]))
+
+def send(obj):
+    b = json.dumps(obj).encode()
+    sys.stdout.buffer.write(struct.pack("<I", len(b)) + b)
+    sys.stdout.buffer.flush()
+
+while True:
+    req = read()
+    if req["op"] == "init":
+        send({"ok": True})
+    elif req["op"] == "transform":
+        compiled = req["source"].replace("<greet/>", '"markup greeting"')
+        send({"ok": True, "output": compiled})
+    else:
+        send({"ok": True})
+"#,
+        );
+
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            std::fs::set_permissions(
+                root.join("mywormdir/worm.py"),
+                std::fs::Permissions::from_mode(0o755),
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn a_claimed_file_bundles_as_the_compiled_luau() {
+        let dir = project(
+            &[
+                (
+                    "main.luaux",
+                    "local msg = <greet/>\nreturn require(\"./join\").with(msg)\n",
+                ),
+                (
+                    "join.luau",
+                    "return { with = function(m) return \"compiled \" .. m end }\n",
+                ),
+            ],
+            &format!(
+                "{}\n[worms.markup]\npath = \"mywormdir\"\n",
+                config_with("[bundle]\nentry = \"src/main.luaux\"\noutput = \"out.luau\"\n")
+            ),
+        );
+
+        install_worm(dir.path());
+
+        let text = run_bundle(dir.path(), &[]).expect("bundles");
+
+        assert!(
+            !text.contains("<greet/>"),
+            "the raw claimed source was bundled: {text}"
+        );
+        assert!(text.contains("markup greeting"), "{text}");
+        assert_eq!(
+            run_luau(&text).expect("runs"),
+            "compiled markup greeting",
+            "the compiled module must run inside the bundle"
+        );
+    }
+}

--- a/crates/larvae/tests/check_cmd.rs
+++ b/crates/larvae/tests/check_cmd.rs
@@ -1,0 +1,234 @@
+//! These tests cover `larvae check` and the [check] analyses end to end.
+
+use std::path::Path;
+use std::process::Command;
+
+fn bin() -> &'static Path {
+    Path::new(env!("CARGO_BIN_EXE_larvae"))
+}
+
+fn write(dir: &Path, name: &str, body: &str) {
+    let path = dir.join(name);
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("makes the directory");
+    }
+
+    std::fs::write(&path, body).expect("writes");
+}
+
+fn run(dir: &Path) -> (bool, String) {
+    let out = Command::new(bin())
+        .arg("check")
+        .current_dir(dir)
+        .output()
+        .expect("runs");
+
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    (out.status.success(), text)
+}
+
+/// A project on the path target, so the checks run with no mounts
+fn path_project(dir: &Path, check: &str) {
+    write(
+        dir,
+        "larvae.toml",
+        &format!("[requires]\ntarget = \"path\"\n{check}"),
+    );
+}
+
+// --- cycles ------------------------------------------------------------------
+
+#[test]
+fn a_require_cycle_names_both_members_and_warns() {
+    let dir = tempfile::tempdir().unwrap();
+    path_project(dir.path(), "");
+    write(dir.path(), "src/a.luau", "return require(\"./b\")\n");
+    write(
+        dir.path(),
+        "src/b.luau",
+        "local a = require(\"./a\")\nreturn a\n",
+    );
+
+    let (ok, out) = run(dir.path());
+
+    assert!(ok, "a warning does not fail the run: {out}");
+    assert!(out.contains("require each other"), "{out}");
+    assert!(out.contains("a.luau") && out.contains("b.luau"), "{out}");
+}
+
+/// The level lever: deny turns the same finding into a failing error
+#[test]
+fn cycles_raised_to_deny_fail_the_run() {
+    let dir = tempfile::tempdir().unwrap();
+    path_project(dir.path(), "[check]\ncycles = \"deny\"\n");
+    write(dir.path(), "src/a.luau", "return require(\"./b\")\n");
+    write(dir.path(), "src/b.luau", "return require(\"./a\")\n");
+
+    let (ok, out) = run(dir.path());
+
+    assert!(!ok, "{out}");
+    assert!(out.contains("require each other"), "{out}");
+}
+
+#[test]
+fn cycles_set_to_allow_say_nothing() {
+    let dir = tempfile::tempdir().unwrap();
+    path_project(dir.path(), "[check]\ncycles = \"allow\"\n");
+    write(dir.path(), "src/a.luau", "return require(\"./b\")\n");
+    write(dir.path(), "src/b.luau", "return require(\"./a\")\n");
+
+    let (ok, out) = run(dir.path());
+
+    assert!(ok, "{out}");
+    assert!(!out.contains("require each other"), "{out}");
+}
+
+/// The graph keys a directory module and its init file on one node
+#[test]
+fn a_cycle_through_a_directory_module_is_found() {
+    let dir = tempfile::tempdir().unwrap();
+    path_project(dir.path(), "");
+    write(
+        dir.path(),
+        "src/consumer.luau",
+        "return require(\"./pkg\")\n",
+    );
+    write(
+        dir.path(),
+        "src/pkg/init.luau",
+        "local c = require(\"./consumer\")\nreturn c\n",
+    );
+
+    let (ok, out) = run(dir.path());
+
+    assert!(ok, "{out}");
+    assert!(out.contains("require each other"), "{out}");
+    assert!(
+        out.contains("consumer.luau") && out.contains("pkg"),
+        "{out}"
+    );
+}
+
+// --- unused modules ----------------------------------------------------------
+
+#[test]
+fn an_unused_module_is_reported_when_asked() {
+    let dir = tempfile::tempdir().unwrap();
+    path_project(dir.path(), "[check]\nunused_modules = \"deny\"\n");
+    write(
+        dir.path(),
+        "src/main.server.luau",
+        "local u = require(\"./used\")\nprint(u)\n",
+    );
+    write(dir.path(), "src/used.luau", "return {}\n");
+    write(dir.path(), "src/orphan.luau", "return {}\n");
+
+    let (ok, out) = run(dir.path());
+
+    assert!(!ok, "{out}");
+    assert!(out.contains("nothing requires this module"), "{out}");
+    assert!(out.contains("orphan.luau"), "{out}");
+    // Roblox runs the server script, so it is never an unused module.
+    assert!(!out.contains("main.server.luau"), "{out}");
+}
+
+/// The escape hatch: an entry in the config is a module the project runs
+#[test]
+fn an_entry_in_the_config_silences_the_unused_report() {
+    let dir = tempfile::tempdir().unwrap();
+    path_project(
+        dir.path(),
+        "[check]\nunused_modules = \"deny\"\nentries = [\"src/orphan.luau\"]\n",
+    );
+    write(dir.path(), "src/orphan.luau", "return {}\n");
+
+    let (ok, out) = run(dir.path());
+
+    assert!(ok, "{out}");
+    assert!(!out.contains("nothing requires this module"), "{out}");
+}
+
+#[test]
+fn unused_modules_stay_quiet_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    path_project(dir.path(), "");
+    write(dir.path(), "src/orphan.luau", "return {}\n");
+
+    let (ok, out) = run(dir.path());
+
+    assert!(ok, "{out}");
+    assert!(!out.contains("nothing requires this module"), "{out}");
+}
+
+// --- early require -----------------------------------------------------------
+
+/// A client project on the instance target, with the given indexing style
+fn instance_project(dir: &Path, style: &str) {
+    write(
+        dir,
+        "larvae.toml",
+        &format!(
+            concat!(
+                "[requires]\n",
+                "target = \"roblox-instance\"\n",
+                "{}\n",
+                "[requires.mounts]\n",
+                "src = \"@game/ReplicatedStorage/app\"\n",
+            ),
+            style
+        ),
+    );
+    write(
+        dir,
+        "src/ui.client.luau",
+        "local h = require(\"./helper\")\nprint(h)\n",
+    );
+    write(dir, "src/helper.luau", "return {}\n");
+}
+
+#[test]
+fn a_client_script_that_does_not_wait_is_reported() {
+    let dir = tempfile::tempdir().unwrap();
+    instance_project(dir.path(), "indexing_style = \"find_first_child\"");
+
+    let (ok, out) = run(dir.path());
+
+    assert!(ok, "a warning does not fail the run: {out}");
+    assert!(out.contains("without waiting for replication"), "{out}");
+    assert!(out.contains("wait_for_child"), "{out}");
+}
+
+#[test]
+fn wait_for_child_silences_the_early_require_check() {
+    let dir = tempfile::tempdir().unwrap();
+    instance_project(dir.path(), "indexing_style = \"wait_for_child\"");
+
+    let (ok, out) = run(dir.path());
+
+    assert!(ok, "{out}");
+    assert!(!out.contains("without waiting for replication"), "{out}");
+}
+
+/// The other targets emit no indexing, so there is no race to report
+#[test]
+fn the_path_target_has_no_replication_race() {
+    let dir = tempfile::tempdir().unwrap();
+    path_project(dir.path(), "");
+    write(
+        dir.path(),
+        "src/ui.client.luau",
+        "local h = require(\"./helper\")\nprint(h)\n",
+    );
+    write(dir.path(), "src/helper.luau", "return {}\n");
+
+    let (ok, out) = run(dir.path());
+
+    assert!(ok, "{out}");
+    assert!(!out.contains("without waiting for replication"), "{out}");
+}

--- a/crates/larvae/tests/fmt.rs
+++ b/crates/larvae/tests/fmt.rs
@@ -929,3 +929,87 @@ fn preserving_gaps_is_still_idempotent() {
 
     assert_eq!(fmt_with(&once, cfg), once);
 }
+
+// --- require_binding -------------------------------------------------------
+
+fn binding(mode: larvae::fmt::config::RequireBinding) -> FmtConfig {
+    FmtConfig {
+        require_binding: mode,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn require_binding_preserves_what_was_written_by_default() {
+    let src = "local A = require(\"@pkg/a\")\nconst B = require(\"@pkg/b\")\nreturn A, B\n";
+
+    assert_eq!(fmt(src), src);
+}
+
+#[test]
+fn const_converts_a_local_require() {
+    assert_eq!(
+        fmt_with(
+            "local Signal = require(\"@pkg/signal\")\nreturn Signal\n",
+            binding(larvae::fmt::config::RequireBinding::Const)
+        ),
+        "const Signal = require(\"@pkg/signal\")\nreturn Signal\n"
+    );
+}
+
+#[test]
+fn local_converts_a_const_require_back() {
+    assert_eq!(
+        fmt_with(
+            "const Signal = require(\"@pkg/signal\")\nreturn Signal\n",
+            binding(larvae::fmt::config::RequireBinding::Local)
+        ),
+        "local Signal = require(\"@pkg/signal\")\nreturn Signal\n"
+    );
+}
+
+/*
+This case would turn a working file into a syntax error. Luau enforces const:
+`Variable 'M' is constant and may not be reassigned`.
+*/
+#[test]
+fn a_require_whose_name_is_reassigned_keeps_local() {
+    let src = "local M = require(\"@pkg/m\")\nM = fallback\nreturn M\n";
+
+    assert_eq!(
+        fmt_with(src, binding(larvae::fmt::config::RequireBinding::Const)),
+        src
+    );
+}
+
+#[test]
+fn only_a_single_unannotated_binding_converts() {
+    let cfg = binding(larvae::fmt::config::RequireBinding::Const);
+
+    for src in [
+        "local A, B = require(\"@pkg/a\"), require(\"@pkg/b\")\nreturn A, B\n",
+        "local S: Signal = require(\"@pkg/signal\")\nreturn S\n",
+        "local x = compute()\nreturn x\n",
+    ] {
+        assert_eq!(fmt_with(src, cfg.clone()), src, "{src:?}");
+    }
+}
+
+/// A require inside a function body is still a require
+#[test]
+fn a_nested_require_converts_too() {
+    let out = fmt_with(
+        "local function f()\n\tlocal S = require(\"@pkg/s\")\n\treturn S\nend\nreturn f\n",
+        binding(larvae::fmt::config::RequireBinding::Const),
+    );
+
+    assert!(out.contains("const S = require"), "{out}");
+}
+
+#[test]
+fn converting_the_binding_is_idempotent() {
+    let cfg = binding(larvae::fmt::config::RequireBinding::Const);
+    let once = fmt_with("local S = require(\"@pkg/s\")\nreturn S\n", cfg.clone());
+
+    assert_eq!(fmt_with(&once, cfg), once);
+}

--- a/crates/larvae/tests/lint.rs
+++ b/crates/larvae/tests/lint.rs
@@ -1175,3 +1175,73 @@ fn deprecated_methods_are_silent_under_plain_luau() {
             .any(|n| n == "deprecated")
     );
 }
+
+// --- non_const_require -----------------------------------------------------
+
+/// `const` is newer than most codebases, so a project must ask for this lint.
+#[test]
+fn non_const_require_is_off_until_a_project_asks() {
+    let src = "local Signal = require(\"@pkg/signal\")\nreturn Signal\n";
+
+    assert!(!fires("non_const_require", src));
+    assert!(
+        fired(src, &with("non_const_require", Level::Warn))
+            .iter()
+            .any(|n| n == "non_const_require")
+    );
+}
+
+fn const_lint(src: &str) -> bool {
+    fired(src, &with("non_const_require", Level::Warn))
+        .iter()
+        .any(|n| n == "non_const_require")
+}
+
+#[test]
+fn a_local_bound_to_a_require_is_reported() {
+    assert!(const_lint(
+        "local Signal = require(\"@pkg/signal\")\nreturn Signal\n"
+    ));
+}
+
+#[test]
+fn one_already_const_is_not() {
+    assert!(!const_lint(
+        "const Signal = require(\"@pkg/signal\")\nreturn Signal\n"
+    ));
+}
+
+/*
+Advice to make a reassigned name const produces `Variable 'X' is constant
+and may not be reassigned`, which is worse than silence.
+*/
+#[test]
+fn a_require_whose_name_is_reassigned_is_left_alone() {
+    assert!(!const_lint(
+        "local M = require(\"@pkg/m\")\nM = fallback\nreturn M\n"
+    ));
+}
+
+/// The lint matches the const_requires transform: one name, one value, no annotation.
+#[test]
+fn the_shapes_const_cannot_express_are_skipped() {
+    assert!(!const_lint(
+        "local A, B = require(\"@pkg/a\"), require(\"@pkg/b\")\nreturn A, B\n"
+    ));
+    assert!(!const_lint(
+        "local S: Signal = require(\"@pkg/signal\")\nreturn S\n"
+    ));
+}
+
+#[test]
+fn a_local_that_is_not_a_require_is_not_its_business() {
+    assert!(!const_lint("local x = compute()\nreturn x\n"));
+}
+
+/// A local named require is not the global require.
+#[test]
+fn a_shadowed_require_says_nothing_about_modules() {
+    assert!(!const_lint(
+        "local require = myLoader\nlocal S = require(\"x\")\nreturn S\n"
+    ));
+}

--- a/crates/larvae/tests/schema.rs
+++ b/crates/larvae/tests/schema.rs
@@ -120,6 +120,50 @@ fn fmt_options_match_the_config() {
     );
 }
 
+/// The schema lists every [bundle] key, and no other key.
+#[test]
+fn bundle_keys_match_the_config() {
+    let schema = schema();
+    let documented = keys(&schema["$defs"]["bundle"]["properties"]);
+
+    /*
+    Every field set, because toml omits a `None` on serialization. The
+    default config would serialize `tree_shake` alone, and the test would
+    compare three documented keys against one real key.
+    */
+    let full = larvae::config::bundle::BundleConfig {
+        entry: Some("src/main.luau".into()),
+        output: Some("bundle.luau".into()),
+        tree_shake: true,
+    };
+
+    let real: BTreeSet<String> = toml::Value::try_from(full)
+        .expect("the config serializes")
+        .as_table()
+        .expect("a table")
+        .keys()
+        .cloned()
+        .collect();
+
+    assert_eq!(
+        documented.difference(&real).collect::<Vec<_>>(),
+        Vec::<&String>::new(),
+        "the schema offers [bundle] keys that do not exist"
+    );
+
+    assert_eq!(
+        real.difference(&documented).collect::<Vec<_>>(),
+        Vec::<&String>::new(),
+        "these [bundle] keys are missing from the schema"
+    );
+
+    // The config denies unknown fields, so the schema must too.
+    assert_eq!(
+        schema["$defs"]["bundle"]["additionalProperties"],
+        serde_json::json!(false)
+    );
+}
+
 /// A ref to a def that does not exist documents nothing, and gives no error.
 #[test]
 fn every_ref_resolves() {


### PR DESCRIPTION
The feat/finish-m3 branch held ~5400 lines that never merged and predate the worm system. This ports the four features worth keeping, rebased onto today's architecture and verified against it: 31 test suites, clippy with -D warnings, and the schema parity tests all pass.

- **init detection fixes** — package directories matched on every path component, sibling mounts collapsed to their parent, no duplicate aliases. Wrong-output bugs in the onboarding command.
- **`larvae self sync-luaurc`** — project aliases written into `.luaurc` as filesystem paths luau-lsp can follow, merged per key, with `--check` for CI.
- **fmt `require_binding` + lint `non_const_require`** — const/local conversion guarded by the scope pass so a reassigned binding is never converted. The same guard fixes `const_requires`, which could emit uncompilable Luau. The lint allows by default, deliberately.
- **`[check]`: require graph, cycles, unused modules, early_require** — Tarjan over a resolved-path graph, levels per analysis like `[lint.rules]`, worm-owned files excluded from the unused report. The schema documented `[check]` while the config refused it; that promise is closed.

Left behind, deliberately: `tier2.rs` (428 lines wired to no caller, superseded by the worm edit path), inline data files (scrapped for a worm per prior decision), and the branch's stale generated schema. Bundle remains on the old branch as a separate go/no-go — it consumes this graph, so it ports cleanly later if wanted.