### PR TITLE
feat(worms): automate worm version bumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Notable changes land here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versions follow
 [semver](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `larvae worm update`, which bumps every worm in larvae.toml to its latest
+  release: the newest GitHub release for a `repo@version` source, the newest
+  stable crate for a `cargo` source, and nothing for a path worm. `--check`
+  reports what waits and fails without writing, for CI. The edit is textual
+  and keeps every other byte, comments included, and a worm that an
+  `extends` base declares is reported rather than edited behind its owner
+
 ## 0.3.0 - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Notable changes land here. Format follows
   reports what waits and fails without writing, for CI. The edit is textual
   and keeps every other byte, comments included, and a worm that an
   `extends` base declares is reported rather than edited behind its owner
+- The editor reports a config that fails to resolve. The server raised no
+  sign before, so a broken larvae.toml meant defaults for a whole session
+  and an editor that looked broken in a quiet way. One warning toast now
+  carries the reason, on start and on each settings reload, and the server
+  still serves defaults until the config loads. A project without a
+  larvae.toml stays quiet, because zero config is a supported state
 
 ## 0.3.0 - 2026-08-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "larvae"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "larvae-worm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/larvae", "crates/larvae-worm"]
 exclude = ["crates/larvae/fuzz", "crates/larvae/tests/fixtures/echo-worm"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/larvae-luau/larvae"

--- a/crates/larvae/src/commands/worm.rs
+++ b/crates/larvae/src/commands/worm.rs
@@ -58,6 +58,16 @@ pub enum WormCommand {
         #[arg(long)]
         stdout: bool,
     },
+
+    /// Bump every worm in larvae.toml to its latest release
+    Update {
+        /// The config to edit; the default is ./larvae.toml
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Report what would change; write nothing, and fail when a bump waits
+        #[arg(long)]
+        check: bool,
+    },
 }
 
 pub fn run(cmd: WormCommand) -> Result<ExitCode> {
@@ -74,7 +84,186 @@ pub fn run(cmd: WormCommand) -> Result<ExitCode> {
         WormCommand::Info { worm } => info(&worm),
 
         WormCommand::Types { out, stdout } => types(out.as_deref(), stdout),
+
+        WormCommand::Update { config, check } => update(config, check),
     }
+}
+
+/*
+`larvae worm update`: every worm in the config, moved to its latest release.
+
+The edit is textual and keeps every other byte, comments included, the same
+approach `larvae init` takes with `.luaurc`. A parse and re-serialize would
+lose the layout of the whole file over one version string.
+
+The command edits the file it was pointed at, and only that file. A worm
+that an `extends` base declares is reported and left alone, because an edit
+to a shared base is a decision for the person who owns it.
+*/
+fn update(config: Option<PathBuf>, check: bool) -> Result<ExitCode> {
+    let path = match config {
+        Some(path) => path,
+
+        None => std::env::current_dir()?.join("larvae.toml"),
+    };
+
+    if !path.exists() {
+        anyhow::bail!("no larvae.toml at {}", crate::ui::rel(&path));
+    }
+
+    let parsed = crate::config::Config::load(&path)?;
+
+    let Some(worms_value) = parsed.worms.as_ref() else {
+        ui::print_success("no [worms] table, nothing to update");
+
+        return Ok(ExitCode::SUCCESS);
+    };
+
+    let worms = crate::config::worms::Worms::parse(worms_value)?;
+    let mut text = std::fs::read_to_string(&path)?;
+    let mut bumped = 0usize;
+    let mut waiting = 0usize;
+    let mut failed = 0usize;
+
+    for (name, entry) in &worms.0 {
+        use crate::config::worms::Source;
+
+        let (base, version) = match &entry.source {
+            Source::Release { repo, version, .. } => (repo.clone(), version.clone()),
+
+            Source::Cargo { package, version } => (package.clone(), version.clone()),
+
+            Source::Local { .. } => {
+                println!("  {name}: a path worm, nothing to bump");
+
+                continue;
+            }
+        };
+
+        let latest = match &entry.source {
+            Source::Release { repo, .. } => crate::net::github::latest_release(repo)
+                .map(|r| r.tag_name.trim_start_matches('v').to_string()),
+
+            Source::Cargo { package, .. } => crate::net::crates_io::latest_version(package),
+
+            Source::Local { .. } => unreachable!("handled above"),
+        };
+
+        let latest = match latest {
+            Ok(latest) => latest,
+
+            Err(e) => {
+                ui::print_error(&format!("{name}: {e:#}"));
+                failed += 1;
+
+                continue;
+            }
+        };
+
+        if !is_older(&version, &latest) {
+            println!("  {name}: up to date ({version})");
+
+            continue;
+        }
+
+        // The user wrote the version with or without a v; keep their form.
+        let written = match version.starts_with('v') {
+            true => format!("v{latest}"),
+
+            false => latest.clone(),
+        };
+
+        match bump(&text, name, &base, &version, &written) {
+            Some(next) => {
+                println!("  {name}: {version} -> {written}");
+                text = next;
+                bumped += 1;
+                waiting += 1;
+            }
+
+            None => {
+                ui::print_error(&format!(
+                    "{name}: {version} -> {written}, but its source is not written in {}; an extends base declares it, so edit that file",
+                    crate::ui::rel(&path)
+                ));
+                failed += 1;
+            }
+        }
+    }
+
+    if check {
+        if waiting > 0 {
+            println!("\n{waiting} update(s) waiting; run `larvae worm update` to write them");
+
+            return Ok(ExitCode::FAILURE);
+        }
+    } else if bumped > 0 {
+        std::fs::write(&path, &text)?;
+        ui::print_success(&format!(
+            "updated {bumped} worm(s) in {}",
+            crate::ui::rel(&path)
+        ));
+    } else if failed == 0 {
+        ui::print_success("every worm is current");
+    }
+
+    Ok(match failed {
+        0 => ExitCode::SUCCESS,
+
+        _ => ExitCode::FAILURE,
+    })
+}
+
+/// True when `current` sits before `latest`; unparseable versions compare as text
+fn is_older(current: &str, latest: &str) -> bool {
+    let bare = current.trim_start_matches('v');
+
+    match (semver::Version::parse(bare), semver::Version::parse(latest)) {
+        (Ok(a), Ok(b)) => a < b,
+
+        // A tag that is not semver still updates when the text differs.
+        _ => bare != latest,
+    }
+}
+
+/*
+The version of one worm in the text of the config, replaced in place.
+
+Two spellings hold a version. The pin forms, `"owner/repo@1.0"` and
+`cargo = "pkg@1.0"`, keep it inside one string with the source, and the
+replacement of that whole string cannot touch another worm. The table form
+keeps `version = "1.0"` as its own key, so the replacement happens only
+inside the table of this worm: from its `[worms.<name>]` header or its
+inline `<name> = {` line, up to the next header. Without that bound, two
+worms pinned to the same version would take each other's update.
+*/
+fn bump(text: &str, name: &str, base: &str, old: &str, new: &str) -> Option<String> {
+    let pin = format!("{base}@{old}");
+
+    if text.contains(&pin) {
+        return Some(text.replace(&pin, &format!("{base}@{new}")));
+    }
+
+    let region_start = ["[worms.{n}]", "[worms.\"{n}\"]", "{n} = {"]
+        .iter()
+        .find_map(|form| text.find(&form.replace("{n}", name)))?;
+
+    let region_end = text[region_start..]
+        .find("\n[")
+        .map(|at| region_start + at)
+        .unwrap_or(text.len());
+
+    let region = &text[region_start..region_end];
+    let key = region.find("version")?;
+    let quoted = format!("\"{old}\"");
+    let at = region_start + key + region[key..].find(&quoted)?;
+
+    let mut out = String::with_capacity(text.len());
+    out.push_str(&text[..at]);
+    out.push_str(&format!("\"{new}\""));
+    out.push_str(&text[at + quoted.len()..]);
+
+    Some(out)
 }
 
 fn run_worm(
@@ -458,5 +647,69 @@ mod tests {
             .set_name("worm.d.luau")
             .into_function()
             .expect("worm.d.luau is valid Luau");
+    }
+}
+
+#[cfg(test)]
+mod update_tests {
+    use super::{bump, is_older};
+
+    #[test]
+    fn the_pin_form_bumps_inside_its_string() {
+        let text = "[worms]\nluaux = \"luau-xml/worm@0.1.0\"\n";
+        let out = bump(text, "luaux", "luau-xml/worm", "0.1.0", "0.2.0").unwrap();
+
+        assert_eq!(out, "[worms]\nluaux = \"luau-xml/worm@0.2.0\"\n");
+    }
+
+    #[test]
+    fn the_cargo_form_bumps_the_same_way() {
+        let text = "[worms.x]\ncargo = \"x-worm@1.0.0\"\n";
+        let out = bump(text, "x", "x-worm", "1.0.0", "1.1.0").unwrap();
+
+        assert!(out.contains("x-worm@1.1.0"), "{out}");
+    }
+
+    #[test]
+    fn the_table_form_bumps_its_own_version_key() {
+        let text = "[worms.a]\nrepo = \"o/a\"\nversion = \"1.0.0\"\n\n[worms.b]\nrepo = \"o/b\"\nversion = \"1.0.0\"\n";
+        let out = bump(text, "b", "o/b", "1.0.0", "2.0.0").unwrap();
+
+        // Two worms share the version; only worm b moves.
+        assert!(out.contains("repo = \"o/a\"\nversion = \"1.0.0\""), "{out}");
+        assert!(out.contains("repo = \"o/b\"\nversion = \"2.0.0\""), "{out}");
+    }
+
+    #[test]
+    fn the_inline_table_form_bumps_too() {
+        let text = "[worms]\na = { repo = \"o/a\", version = \"1.0.0\" }\n";
+        let out = bump(text, "a", "o/a", "1.0.0", "1.2.0").unwrap();
+
+        assert!(out.contains("version = \"1.2.0\""), "{out}");
+    }
+
+    #[test]
+    fn a_source_the_file_does_not_hold_returns_nothing() {
+        // The worm comes through an extends base, so this file has no entry.
+        assert!(bump("input = \"src\"\n", "a", "o/a", "1.0.0", "2.0.0").is_none());
+    }
+
+    #[test]
+    fn comments_and_layout_survive_a_bump() {
+        let text = "# keep me\n[worms.a]\nrepo = \"o/a\"   # and me\nversion = \"1.0.0\"\n";
+        let out = bump(text, "a", "o/a", "1.0.0", "1.0.1").unwrap();
+
+        assert!(out.contains("# keep me"));
+        assert!(out.contains("# and me"));
+    }
+
+    #[test]
+    fn older_compares_as_semver_and_falls_back_to_text() {
+        assert!(is_older("0.1.0", "0.2.0"));
+        assert!(!is_older("0.2.0", "0.2.0"));
+        // A pinned prerelease past the latest stable stays where it is.
+        assert!(!is_older("0.3.0-beta", "0.2.9"));
+        assert!(is_older("v0.1.0", "0.1.1"));
+        assert!(is_older("nightly-1", "nightly-2"));
     }
 }

--- a/crates/larvae/src/lsp/mod.rs
+++ b/crates/larvae/src/lsp/mod.rs
@@ -98,7 +98,7 @@ impl Server {
     pub(super) fn handle(&mut self, message: &rpc::Message, out: &mut impl Write) -> Result<bool> {
         match message.method.as_str() {
             "initialize" => {
-                self.initialize(&message.params);
+                self.initialize(&message.params, out)?;
 
                 self.reply(message, out, capabilities())?;
             }
@@ -120,7 +120,7 @@ impl Server {
             broken.
             */
             "workspace/didChangeConfiguration" => {
-                self.load_config();
+                self.load_config(out)?;
 
                 for uri in self.documents.keys().cloned().collect::<Vec<_>>() {
                     self.publish(&uri, out)?;

--- a/crates/larvae/src/lsp/state.rs
+++ b/crates/larvae/src/lsp/state.rs
@@ -3,20 +3,22 @@ What the server holds between requests: the config of the project and its
 worms, and the reloads that keep both current.
 */
 
+use std::io::Write;
 use std::path::Path;
 
-use serde_json::Value;
+use anyhow::Result;
+use serde_json::{Value, json};
 
 use crate::commands::fmt::pool_with;
 use crate::fmt::FmtConfig;
 use crate::lint::LintConfig;
 use crate::worm::pool::Pool;
 
-use super::Server;
 use super::uri::path_of_uri;
+use super::{Server, rpc};
 
 impl Server {
-    pub(super) fn initialize(&mut self, params: &Value) {
+    pub(super) fn initialize(&mut self, params: &Value, out: &mut impl Write) -> Result<()> {
         self.root = params["rootUri"]
             .as_str()
             .and_then(path_of_uri)
@@ -26,43 +28,71 @@ impl Server {
                     .and_then(path_of_uri)
             });
 
-        self.load_config();
+        self.load_config(out)
     }
 
     /*
     Read the config of the project, with the defaults as the fallback.
 
-    The server does not report a broken config here. The user edits that
-    config in the editor. A server that refuses to start because the file is
-    incomplete is worse than one that formats with defaults until the save.
+    A broken config does not stop the server, because the user edits that
+    config in the editor, and a server that refuses to start over an
+    incomplete file is not usable. But silence is wrong too: a project that
+    formats with defaults for a whole session looks broken in a quieter
+    way. So a config that fails to resolve raises one editor notification,
+    and the message carries the reason. A project without a larvae.toml is
+    the zero config case and raises nothing.
     */
-    pub(super) fn load_config(&mut self) {
+    pub(super) fn load_config(&mut self, out: &mut impl Write) -> Result<()> {
         // The load of the worms takes `&mut self`, so the root arrives as a copy.
         let Some(root) = self.root.clone() else {
-            return;
+            return Ok(());
         };
 
-        let project = crate::config::Config::load(&root.join("larvae.toml")).ok();
+        let path = root.join("larvae.toml");
 
-        if let Ok(cfg) = FmtConfig::discover(&root, project.as_ref().and_then(|c| c.fmt.as_ref())) {
-            self.fmt = cfg;
+        let project = match path.exists() {
+            true => match crate::config::Config::load(&path) {
+                Ok(cfg) => Some(cfg),
+
+                Err(e) => {
+                    warn(
+                        out,
+                        &format!("{e:#}; larvae serves defaults until it loads"),
+                    )?;
+
+                    None
+                }
+            },
+
+            false => None,
+        };
+
+        match FmtConfig::discover(&root, project.as_ref().and_then(|c| c.fmt.as_ref())) {
+            Ok(cfg) => self.fmt = cfg,
+
+            Err(e) => warn(out, &format!("{e:#}"))?,
         }
 
-        if let Ok(cfg) = LintConfig::discover(&root, project.as_ref().and_then(|c| c.lint.as_ref()))
-        {
-            // The root lists apply here too, so the editor and the command agree.
-            let (root_in, root_ex) = project
-                .as_ref()
-                .map(|c| (c.include.as_slice(), c.exclude.as_slice()))
-                .unwrap_or((&[], &[]));
+        match LintConfig::discover(&root, project.as_ref().and_then(|c| c.lint.as_ref())) {
+            Ok(cfg) => {
+                // The root lists apply here too, so the editor and the command agree.
+                let (root_in, root_ex) = project
+                    .as_ref()
+                    .map(|c| (c.include.as_slice(), c.exclude.as_slice()))
+                    .unwrap_or((&[], &[]));
 
-            self.excluded = cfg
-                .excludes_under(&root, root_in, root_ex)
-                .unwrap_or_default();
-            self.lint = cfg;
+                self.excluded = cfg
+                    .excludes_under(&root, root_in, root_ex)
+                    .unwrap_or_default();
+                self.lint = cfg;
+            }
+
+            Err(e) => warn(out, &format!("{e:#}"))?,
         }
 
         self.load_worms(&root);
+
+        Ok(())
     }
 
     /*
@@ -113,6 +143,20 @@ impl Server {
             self.load_worms(&root);
         }
     }
+}
+
+/*
+One warning toast in the editor; `window/showMessage` type 2 is Warning.
+
+The protocol allows this notification before the reply to `initialize`, so
+a config that is broken at startup reports right away.
+*/
+fn warn(out: &mut impl Write, message: &str) -> Result<()> {
+    rpc::notify(
+        out,
+        "window/showMessage",
+        json!({ "type": 2, "message": message }),
+    )
 }
 
 /*

--- a/crates/larvae/src/lsp/tests.rs
+++ b/crates/larvae/src/lsp/tests.rs
@@ -562,7 +562,107 @@ fn a_project_config_that_does_not_load_leaves_the_server_with_no_worms() {
         ..Default::default()
     };
 
-    server.load_config();
+    server.load_config(&mut Vec::new()).unwrap();
 
     assert!(server.worms.is_empty());
+}
+
+/// The uri of a directory on disk, in the form the editor sends
+fn dir_uri(path: &std::path::Path) -> String {
+    let text = path.display().to_string().replace('\\', "/");
+
+    format!("file:///{}", text.trim_start_matches('/'))
+}
+
+fn initialized_at(dir: &std::path::Path) -> String {
+    let mut server = Server::default();
+    let mut out = Vec::new();
+
+    server
+        .handle(
+            &message("initialize", Some(1), json!({ "rootUri": dir_uri(dir) })),
+            &mut out,
+        )
+        .unwrap();
+
+    String::from_utf8(out).unwrap()
+}
+
+/// A config that fails to resolve raises one editor notification.
+#[test]
+fn a_broken_config_raises_a_warning_toast() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("larvae.toml"), "[process]\ninpt = \"x\"\n").unwrap();
+
+    let out = initialized_at(dir.path());
+
+    assert!(out.contains("window/showMessage"), "{out}");
+    assert!(out.contains("larvae serves defaults"), "{out}");
+    // The server still answers initialize; a broken config does not stop it.
+    assert!(out.contains("documentFormattingProvider"), "{out}");
+}
+
+/// No larvae.toml is the zero config case, and it raises nothing.
+#[test]
+fn a_missing_config_stays_quiet() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = initialized_at(dir.path());
+
+    assert!(!out.contains("window/showMessage"), "{out}");
+}
+
+#[test]
+fn a_clean_config_stays_quiet() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("larvae.toml"),
+        "[fmt]\ncolumn_width = 100\n",
+    )
+    .unwrap();
+
+    let out = initialized_at(dir.path());
+
+    assert!(!out.contains("window/showMessage"), "{out}");
+}
+
+/// A settings change reloads the config, so the report happens there too.
+#[test]
+fn a_config_change_reports_the_break_again() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("larvae.toml"),
+        "[fmt]\ncolumn_width = 100\n",
+    )
+    .unwrap();
+
+    let mut server = Server::default();
+    let mut out = Vec::new();
+    server
+        .handle(
+            &message(
+                "initialize",
+                Some(1),
+                json!({ "rootUri": dir_uri(dir.path()) }),
+            ),
+            &mut out,
+        )
+        .unwrap();
+
+    std::fs::write(dir.path().join("larvae.toml"), "[process]\ninpt = \"x\"\n").unwrap();
+
+    let mut out = Vec::new();
+    server
+        .handle(
+            &message("workspace/didChangeConfiguration", None, json!({})),
+            &mut out,
+        )
+        .unwrap();
+
+    assert!(
+        String::from_utf8(out)
+            .unwrap()
+            .contains("window/showMessage"),
+        "the reload reports the break"
+    );
 }

--- a/crates/larvae/src/lsp/uri.rs
+++ b/crates/larvae/src/lsp/uri.rs
@@ -24,33 +24,28 @@ project config; no other function breaks.
 pub(super) fn path_of_uri(uri: &str) -> Option<PathBuf> {
     let rest = uri.strip_prefix("file://")?;
 
-    // On Windows the path arrives as /C:/thing; remove the leading slash.
-    let rest = match rest.get(..3) {
-        Some(p) if p.starts_with('/') && p.as_bytes()[2] == b':' => &rest[1..],
+    let mut bytes = Vec::with_capacity(rest.len());
+    let mut it = rest.bytes();
 
-        _ => rest,
-    };
-
-    let mut out = String::with_capacity(rest.len());
-    let mut chars = rest.chars();
-
-    while let Some(c) = chars.next() {
-        if c != '%' {
-            out.push(c);
-
+    while let Some(b) = it.next() {
+        if b != b'%' {
+            bytes.push(b);
             continue;
         }
 
-        let hex: String = chars.by_ref().take(2).collect();
+        let (hi, lo) = (it.next()?, it.next()?);
 
-        match u8::from_str_radix(&hex, 16) {
-            Ok(byte) => out.push(byte as char),
-
-            Err(_) => {
-                out.push('%');
-                out.push_str(&hex);
-            }
+        match u8::from_str_radix(std::str::from_utf8(&[hi, lo]).ok()?, 16) {
+            Ok(byte) => bytes.push(byte),
+            Err(_) => bytes.extend([b'%', hi, lo]),
         }
+    }
+
+    // Decode first, then the drive check sees the real colon.
+    let mut out = String::from_utf8(bytes).ok()?;
+
+    if out.len() >= 3 && out.as_bytes()[0] == b'/' && out.as_bytes()[2] == b':' {
+        out.remove(0);
     }
 
     Some(PathBuf::from(out))

--- a/crates/larvae/src/net/crates_io.rs
+++ b/crates/larvae/src/net/crates_io.rs
@@ -1,0 +1,29 @@
+//! The crates.io API (the part that `worm update` needs)
+
+use anyhow::Result;
+
+#[derive(serde::Deserialize)]
+struct Index {
+    #[serde(rename = "crate")]
+    package: Package,
+}
+
+#[derive(serde::Deserialize)]
+struct Package {
+    /// The newest version that is not a prerelease and not yanked
+    max_stable_version: Option<String>,
+    /// The newest version of any kind, the fallback for a crate with
+    /// prereleases only
+    max_version: String,
+}
+
+/// The latest version of one crate, stable when the crate has one
+pub fn latest_version(package: &str) -> Result<String> {
+    let index: Index =
+        super::http::get_json(&format!("https://crates.io/api/v1/crates/{package}"), &[])?;
+
+    Ok(index
+        .package
+        .max_stable_version
+        .unwrap_or(index.package.max_version))
+}

--- a/crates/larvae/src/net/mod.rs
+++ b/crates/larvae/src/net/mod.rs
@@ -1,4 +1,5 @@
 //! Network access: a small blocking HTTP layer and the GitHub releases API
 
+pub mod crates_io;
 pub mod github;
 pub mod http;


### PR DESCRIPTION
Add the larvae worm update command which will fetch the latest release version for all worms in the larvae.toml and update them all if any.

Fix a bug with windows resolving file paths.