### PR TITLE
fix(bundle): follow the requires of a vendored package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Notable changes land here. Format follows
 
 ## Unreleased
 
+### Fixed
+
+- A bundle follows the requires of a vendored package. The pipeline
+  resolves the input tree only, so the graph ended at the door of a module
+  outside the roots: `require("./lib")` inside a package shipped raw and
+  failed inside the bundle. The bundler now walks those modules until the
+  graph closes, with the same resolver, the same `.luaurc` walk, and the
+  same `@self`, so a package that requires a package follows too
+- `@self` requires enter the require graph. They passed through as
+  natively valid and never recorded an edge, so `check` could not follow a
+  cycle through one and a bundle dropped what one named
+- A resolution failure inside a vendored module warns instead of stopping
+  the bundle, because a package can require another runtime, ex:
+  `task or require("@lune/task")`; the require ships as written
+- `export type` loses its `export` inside a bundle. The keyword is legal
+  at the top level of a module only, and the bundle wraps every module in
+  a function, so the bundle of a module that re-exported types did not
+  parse
+
 ### Added
 
 - The syntax of three merged Luau RFCs. Classes: `[export] [open] class

--- a/crates/larvae/src/bundle/mod.rs
+++ b/crates/larvae/src/bundle/mod.rs
@@ -154,7 +154,43 @@ pub fn rewrite(src: &str, path: &Path, plan: &Plan, diags: &mut Vec<Diag>) -> Re
         );
     }
 
-    let mut out = src.to_string();
+    /*
+    Every change is one splice list, sorted and applied back to front, so
+    each earlier offset stays valid whatever order the changes were found
+    in. Two kinds of change land here. A require splice points the call
+    into the bundle. An `export type` loses its `export`: the keyword is
+    legal at the top level of a module only, the bundle wraps every module
+    in a function, and a plain `type` alias is legal in any block while
+    changing nothing at run time.
+
+    `export local` and its siblings stay, because their run time meaning
+    is the module's value, and a bundle cannot erase that without changing
+    what the module returns. A runtime that accepts them at the top level
+    is the runtime this bundle targets.
+    */
+    let mut splices: Vec<(usize, usize, String)> = Vec::new();
+
+    if let Ok(chunk) = crate::syntax::parser::parse(src, &lexed.toks) {
+        for stmt in &chunk.block.stmts {
+            if let crate::syntax::ast::Stmt::TypeAlias(alias) = stmt
+                && alias.exported
+            {
+                let tok = &lexed.toks[alias.span.start as usize];
+
+                if tok.text(src) == "export" {
+                    let start = tok.start as usize;
+                    let end = start
+                        + "export".len()
+                        + src[start + "export".len()..]
+                            .chars()
+                            .take_while(|c| *c == ' ')
+                            .count();
+
+                    splices.push((start, end, String::new()));
+                }
+            }
+        }
+    }
 
     /*
     Two splices per require: the string token becomes the module id, and the
@@ -164,20 +200,30 @@ pub fn rewrite(src: &str, path: &Path, plan: &Plan, diags: &mut Vec<Diag>) -> Re
     halves. `f "x"` without parentheses is a call too, and the two splices
     handle it without more knowledge.
     */
-    for site in plan.graph.sites_of(path).iter().rev() {
+    for site in plan.graph.sites_of(path) {
         let Some(id) = plan.modules.get(&site.target) else {
             continue;
         };
 
-        out.replace_range(
-            site.tok_start as usize..site.tok_end as usize,
-            &emit::quote(id),
-        );
+        splices.push((
+            site.tok_start as usize,
+            site.tok_end as usize,
+            emit::quote(id),
+        ));
 
-        out.replace_range(
-            site.at as usize..site.at as usize + "require".len(),
-            "__require",
-        );
+        splices.push((
+            site.at as usize,
+            site.at as usize + "require".len(),
+            "__require".to_string(),
+        ));
+    }
+
+    splices.sort_by_key(|(start, _, _)| *start);
+
+    let mut out = src.to_string();
+
+    for (start, end, text) in splices.iter().rev() {
+        out.replace_range(start..end, text);
     }
 
     Ok(out)

--- a/crates/larvae/src/pipeline/mod.rs
+++ b/crates/larvae/src/pipeline/mod.rs
@@ -516,12 +516,156 @@ fn run_inner(
         }
     }
 
+    let mut graph = shared_graph.into_inner().unwrap();
+    let mut sources = shared_sources.into_inner().unwrap();
+
+    if keep_sources && collect_graph {
+        absorb_external(&resolver, &mut graph, &mut sources, &mut diags);
+    }
+
     diag::sort(&mut diags);
     Ok(Outcome {
         stats,
         diags,
         build_project,
-        graph: shared_graph.into_inner().unwrap(),
-        sources: shared_sources.into_inner().unwrap(),
+        graph,
+        sources,
     })
+}
+
+/*
+The modules outside the input roots, resolved into the graph.
+
+A project requires a vendored package, and the package requires its own
+files. The pipeline resolves the input tree only, so the graph used to end
+at the package's door: the file was a node, but its own requires stayed
+unknown, and a bundle shipped them raw, `require("./lib")` and all. This
+pass walks those doors until the graph closes. Each node without processed
+text is read and resolved exactly as an input file is: the same resolver,
+the same `.luaurc` walk, the same `@self`. What it requires joins the
+worklist, so a package that requires a package follows too.
+
+The text goes into `sources` untouched, and the recorded sites index it.
+So the bundler rewrites the requires of a vendored file without larvae
+editing a byte of it first.
+
+A node that cannot be read still gains an entry, because the worklist
+keys on absence, and the error beside it stops the bundle before the
+entry could ship.
+*/
+fn absorb_external(
+    resolver: &crate::requires::resolve::Resolver,
+    graph: &mut crate::requires::graph::Graph,
+    sources: &mut std::collections::BTreeMap<PathBuf, String>,
+    diags: &mut Vec<Diag>,
+) {
+    loop {
+        let missing: Vec<PathBuf> = graph
+            .nodes()
+            .filter(|n| !sources.contains_key(*n))
+            .map(Path::to_path_buf)
+            .collect();
+
+        if missing.is_empty() {
+            return;
+        }
+
+        for node in missing {
+            let file = match external_file(&node) {
+                Some(file) => file,
+
+                None => {
+                    diags.push(Diag::error(
+                        &node,
+                        "a module resolves here, and no file answers to it",
+                    ));
+                    sources.insert(node, String::new());
+
+                    continue;
+                }
+            };
+
+            let text = match std::fs::read_to_string(&file) {
+                Ok(text) => text,
+
+                Err(e) => {
+                    diags.push(Diag::error(&file, format!("cannot read file: {e}")));
+                    sources.insert(node, String::new());
+
+                    continue;
+                }
+            };
+
+            let lexed = match crate::syntax::lexer::lex(&text) {
+                Ok(lexed) => lexed,
+
+                Err(e) => {
+                    diags.push(
+                        Diag::error(&file, format!("lex error: {}", e.message)).at(&text, e.offset),
+                    );
+                    sources.insert(node, text);
+
+                    continue;
+                }
+            };
+
+            let scanned = crate::syntax::scan::scan(&text, &lexed.toks);
+            let ctx = crate::requires::resolve::FileCtx::new(
+                &file,
+                resolver.mounts,
+                resolver.target,
+                resolver.style,
+            );
+
+            for site in &scanned.sites {
+                let spec = &text[site.inner_start as usize..site.inner_end as usize];
+                let before = ctx.required.borrow().len();
+
+                /*
+                The rewrite decision is dropped: this text is never
+                spliced. A resolution failure downgrades to a warning,
+                because the module is vendored and its author is not here:
+                a package can hold a require for another runtime, ex:
+                `task or require("@lune/task")`, that never runs where the
+                bundle runs. The require ships into the bundle as written,
+                which is what the module does without a bundle too.
+                */
+                let mut local: Vec<Diag> = Vec::new();
+                let _ = resolver.resolve(&ctx, spec, &text, site.at as usize, &mut local);
+
+                for mut d in local {
+                    d.severity = diag::Severity::Warning;
+                    diags.push(d);
+                }
+
+                if let Some(target) = ctx.required.borrow().get(before) {
+                    graph.add(&node, target);
+                    graph.add_site(
+                        &node,
+                        crate::requires::graph::Site {
+                            at: site.at,
+                            tok_start: site.tok_start,
+                            tok_end: site.tok_end,
+                            target: target.clone(),
+                        },
+                    );
+                }
+            }
+
+            graph.see(&node);
+            sources.insert(node, text);
+        }
+    }
+}
+
+/// The file behind a graph node; a directory node answers with its init file
+fn external_file(node: &Path) -> Option<PathBuf> {
+    if node.is_dir() {
+        return ["init.luau", "init.lua"]
+            .iter()
+            .map(|name| node.join(name))
+            .find(|p| p.is_file());
+    }
+
+    node.is_file().then(|| node.to_path_buf())
 }

--- a/crates/larvae/src/requires/resolve/alias.rs
+++ b/crates/larvae/src/requires/resolve/alias.rs
@@ -43,7 +43,22 @@ impl<'a> Resolver<'a> {
             return self.emit_fs(ctx, spec, &target_base, src, offset, diags);
         }
 
-        // @self is natively valid for the other targets, so it passes through.
+        /*
+        The other targets keep @self as written, because Luau resolves it
+        natively. The graph still needs the edge: `check` follows cycles
+        through it, and a bundle ships the module it names. So the module
+        is located and recorded, and the text stays untouched. A spec that
+        does not locate stays silent here, exactly as it did before the
+        graph learned about @self.
+        */
+        if let Some(base) = normalize_join(&ctx.dir, rest)
+            && let Ok(Some(node)) = super::spec::resolve_module(&base)
+        {
+            ctx.required
+                .borrow_mut()
+                .push(node.dm_key_path().to_path_buf());
+        }
+
         Rewrite::Keep
     }
 

--- a/crates/larvae/tests/bundle.rs
+++ b/crates/larvae/tests/bundle.rs
@@ -463,3 +463,120 @@ fn a_dense_bundle_still_runs() {
     assert!(!text.contains("a comment"), "comments are trivia: {text}");
     assert_eq!(run_luau(&text).unwrap(), "ok");
 }
+
+/*
+The shape of a vendored dependency: a package outside the input roots,
+reached through an alias, whose own files require each other with `./`
+and `@self`. The pipeline resolves the input tree only, so the bundler
+absorbs the rest by walking the graph until it closes.
+*/
+#[test]
+fn a_vendored_package_outside_the_roots_bundles_whole() {
+    let dir = project(
+        &[(
+            "init.luau",
+            "local lib = require(\"@pkg/lib\")\nreturn lib.word()\n",
+        )],
+        concat!(
+            "[process]\ninput = \"src\"\n\n[requires]\ntarget = \"path\"\n\n",
+            "[bundle]\nentry = \"src/init.luau\"\noutput = \"out.luau\"\n"
+        ),
+    );
+    let root = dir.path();
+
+    write(
+        root,
+        ".luaurc",
+        "{ \"aliases\": { \"pkg\": \"packages\" } }",
+    );
+    write(
+        root,
+        "packages/lib.luau",
+        "local module = require(\"./.vendor/lib/src\")\nreturn module\n",
+    );
+    write(
+        root,
+        "packages/.vendor/lib/src/init.luau",
+        "local greet = require(\"@self/greet\")\nreturn { word = function() return greet.hello() end }\n",
+    );
+    write(
+        root,
+        "packages/.vendor/lib/src/greet.luau",
+        "local tail = require(\"./tail\")\nreturn { hello = function() return \"hi\" .. tail end }\n",
+    );
+    write(root, "packages/.vendor/lib/src/tail.luau", "return \"!\"\n");
+
+    let text = run_bundle(root, &[]).expect("bundles");
+
+    assert_eq!(run_luau(&text).expect("runs"), "hi!");
+    assert!(
+        !text.contains("require(\"./"),
+        "a relative require survived: {text}"
+    );
+    assert!(!text.contains("@self"), "an @self require survived: {text}");
+}
+
+/*
+A vendored module can require another runtime, ex: `task or
+require("@lune/task")`. The author of that file is not here, so the
+resolution failure warns instead of stopping the bundle, and the require
+ships as written, which is what the module does without a bundle too.
+*/
+#[test]
+fn an_unknown_alias_inside_a_vendored_module_warns_and_ships() {
+    let dir = project(
+        &[(
+            "init.luau",
+            "local lib = require(\"@pkg/lib\")\nreturn lib\n",
+        )],
+        concat!(
+            "[process]\ninput = \"src\"\n\n[requires]\ntarget = \"path\"\n\n",
+            "[bundle]\nentry = \"src/init.luau\"\noutput = \"out.luau\"\n"
+        ),
+    );
+    let root = dir.path();
+
+    write(
+        root,
+        ".luaurc",
+        "{ \"aliases\": { \"pkg\": \"packages\" } }",
+    );
+    write(
+        root,
+        "packages/lib.luau",
+        "local t = string or require(\"@lune/task\")\nreturn \"ok\"\n",
+    );
+
+    let text = run_bundle(root, &[]).expect("a vendored unknown alias must not stop the bundle");
+
+    assert!(text.contains("require(\"@lune/task\")"), "{text}");
+    assert_eq!(run_luau(&text).expect("runs"), "ok");
+}
+
+/*
+`export type` is legal at the top level of a module only, and the bundle
+wraps every module in a function. The `export` is erased; the alias stays,
+because a plain `type` is legal in any block and free at run time.
+*/
+#[test]
+fn an_export_type_loses_its_export_inside_the_bundle() {
+    let text = bundle(
+        &[
+            (
+                "main.luau",
+                "local m = require(\"./shim\")\nreturn m.word\n",
+            ),
+            (
+                "shim.luau",
+                "local module = require(\"./real\")\nexport type Word = module.Word\nreturn module\n",
+            ),
+            ("real.luau", "export type Word = string\nreturn { word = \"typed\" }\n"),
+        ],
+        "src/main.luau",
+    )
+    .expect("bundles");
+
+    assert!(!text.contains("export type"), "{text}");
+    assert!(text.contains("type Word"), "the alias itself stays: {text}");
+    assert_eq!(run_luau(&text).expect("runs"), "typed");
+}


### PR DESCRIPTION
Fixes the report where a bundle shipped a vendored package's requires raw: `require("./.lpm/evaera_promise/lib")` stayed as written inside its thunk and failed at run time, and `@self` requires inside packages like fluid never made it into the bundle at all.

## The four changes

- **The bundler absorbs modules outside the input roots.** The pipeline resolves the input tree only, so the graph ended at the package's door. A closure pass now reads and resolves each reached external module exactly as an input file: same resolver, same `.luaurc` walk, same `@self`. What it requires joins the worklist, so a package that requires a package follows too. The reporting workspace went from 2 bundled modules to 36.
- **`@self` requires enter the require graph.** They passed through as natively valid and never recorded an edge, which also blinded `check` to cycles through them. The edge records now; the written text still ships untouched.
- **A resolution failure inside a vendored module warns instead of stopping the bundle.** A package can require another runtime, ex: `task or require("@lune/task")`. The require ships as written, which is what the module does without a bundle.
- **`export type` loses its `export` inside a bundle.** The keyword is top-level only and the bundle wraps every module in a function, so a module re-exporting types produced a bundle that did not parse. A plain `type` alias is legal in any block and free at run time. The rewrite now applies one sorted splice list back to front, so require splices and export splices cannot shift each other.

## Verification

Three new executable tests mirror the report's shape: a vendored package reached through a `.luaurc` alias whose files use `./` and `@self` (bundles whole and runs), the cross-runtime fallback (warns, ships, runs), and export-type stripping (parses, runs). The reporting user's actual workspace bundles and executes under Lune deep into fluid's init, stopping only at `CFrame.identity`, a Roblox global. Full suite and clippy clean.