### PR TITLE
feat(lint): prefer_const rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ Notable changes land here. Format follows
   binding the file mutates through a field, `t.x = 1` or `table.insert(t, 1)`.
   Off by default, because `const` is correct there: Luau enforces it against
   reassignment of the name and says nothing about the value
+- Two LSP paths for worms, wired and empty. `textDocument/codeAction` is
+  advertised and answers with a list, and `larvae/definitions` is a request of
+  larvae's own for the type definitions a worm supplies. Neither carries
+  anything yet: `crates/larvae/src/lsp/extend.rs` is the seam, so the work
+  that fills them touches one file. The capability is advertised now because
+  an editor decides at initialize whether to ever ask
 - `[fmt] function_call` and `[fmt] function_declaration` lay out the two lists
   between parentheses. `expand` takes `when-needed`, which is the layout larvae
   always had, `always`, and `never`. `indent` gives the levels an opened item

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ Notable changes land here. Format follows
 
 ### Added
 
+- `prefer_const`, a lint for a local that nothing reassigns. Off by default,
+  because `const` is larvae's own reading of Luau and a codebase of ordinary
+  `local` would report on nearly every line the first time it ran. It leaves
+  alone what cannot take `const`: a declaration with no initialiser, a
+  `local function`, a `for` variable, and a multi name declaration where one
+  of the names is reassigned
+- `[lint.options.prefer_const] mutated_tables_stay_local` keeps `local` on a
+  binding the file mutates through a field, `t.x = 1` or `table.insert(t, 1)`.
+  Off by default, because `const` is correct there: Luau enforces it against
+  reassignment of the name and says nothing about the value
 - `[fmt] function_call` and `[fmt] function_declaration` lay out the two lists
   between parentheses. `expand` takes `when-needed`, which is the layout larvae
   always had, `always`, and `never`. `indent` gives the levels an opened item

--- a/crates/larvae/larvae.schema.json
+++ b/crates/larvae/larvae.schema.json
@@ -1267,6 +1267,14 @@
           ],
           "description": "Two branches of the same if with identical bodies. Default: warn."
         },
+        "prefer_const": {
+          "enum": [
+            "allow",
+            "warn",
+            "deny"
+          ],
+          "description": "A local that nothing reassigns, which `const` states outright. Off by default: `const` is larvae's own reading of Luau and not every project writes it, so a codebase of ordinary `local` would report on nearly every line the first time it ran. Tune it under [lint.options.prefer_const]. Default: allow."
+        },
         "suspicious_reverse_loop": {
           "enum": [
             "allow",
@@ -1676,6 +1684,21 @@
                 "type": "string"
               },
               "description": "Require paths the project forbids, as path = \"why\"."
+            }
+          }
+        },
+        "prefer_const": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "mutated_tables_stay_local": {
+              "type": "boolean",
+              "enum": [
+                true,
+                false
+              ],
+              "default": false,
+              "description": "Keep `local` on a binding the file mutates through a field, such as `t.x = 1` or `table.insert(t, 1)`. Off by default, because `const` is correct there: Luau enforces it against reassignment of the name and says nothing about the value, so `const t = {}` then `t.x = 1` compiles. Turn it on where `local` is read as \"this one changes\"."
             }
           }
         }

--- a/crates/larvae/src/lint/lints/configured.rs
+++ b/crates/larvae/src/lint/lints/configured.rs
@@ -28,6 +28,8 @@ lints! {
         "calling a function in this file with the wrong number of arguments";
     MustUse => "must_use", Warn,
         "calling a pure function and discarding what it returned";
+    PreferConst => "prefer_const", Allow,
+        "a local that nothing reassigns, which const states outright";
     RestrictedModulePaths => "restricted_module_paths", Warn,
         "requiring a module the project has ruled out";
 }
@@ -794,4 +796,186 @@ impl MismatchedArgCount {
             );
         });
     }
+}
+
+// --- prefer_const ----------------------------------------------------------
+
+#[derive(Deserialize, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct PreferConstOptions {
+    /*
+    A local that the file mutates through a field keeps `local`.
+
+    Off by default, so a mutated table reports like every other binding. It
+    is off because `const` is correct there: Luau enforces `const` against
+    reassignment of the name and says nothing about the value, so
+    `const t = {}` followed by `t.x = 1` compiles. The option is for a project
+    that reads `local` as "this one changes" and wants the two spellings to
+    carry that difference.
+    */
+    pub mutated_tables_stay_local: bool,
+}
+
+impl PreferConst {
+    /*
+    `local x = 1` where nothing assigns `x` again.
+
+    This lint is off by default. `const` is larvae's own reading of Luau and
+    not every project writes it, so a codebase of ordinary `local` would
+    report on nearly every line the first time it ran.
+
+    Three rules keep a report honest, and each one is a place where the
+    suggestion would not compile or would not apply:
+
+    - A declaration with no value stays. `const x` is
+      "Missing initializer in const declaration".
+    - `const` binds the declaration and not one name in it, so every name has
+      to be unassigned before the whole statement can change.
+    - A `for` variable, a parameter, and a `local function` are left alone.
+      None of them takes `const`.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        let options: PreferConstOptions = ctx.cfg.options_for("prefer_const");
+
+        let mutated = match options.mutated_tables_stay_local {
+            true => mutated_bindings(ctx),
+
+            false => std::collections::HashSet::new(),
+        };
+
+        each_stmt(ctx, out, |ctx, s, out| {
+            let Stmt::Local(n) = s else {
+                return;
+            };
+
+            // Already said, and a declaration with nothing to bind cannot say it.
+            if n.is_const || n.values.is_empty() {
+                return;
+            }
+
+            let mut names = Vec::with_capacity(n.names.len());
+
+            for binding in &n.names {
+                let Some(&index) = ctx.names.by_token.get(&binding.name.start) else {
+                    return;
+                };
+
+                if !ctx.names.bindings[index].writes.is_empty() || mutated.contains(&index) {
+                    return;
+                }
+
+                names.push(ctx.text(binding.name));
+            }
+
+            let subject = match names.as_slice() {
+                [one] => format!("`{one}` is never reassigned"),
+
+                many => format!("{} are never reassigned", quoted(many)),
+            };
+
+            out.push(
+                Finding::new("prefer_const", ctx.bytes(n.keyword), subject)
+                    .with_help("declare it with `const`, which states that outright"),
+            );
+        });
+    }
+}
+
+/// `a`, `b` and `c`, so the message reads as a sentence.
+fn quoted(names: &[&str]) -> String {
+    let quoted: Vec<String> = names.iter().map(|n| format!("`{n}`")).collect();
+
+    match quoted.split_last() {
+        Some((last, [])) => last.clone(),
+
+        Some((last, rest)) => format!("{} and {last}", rest.join(", ")),
+
+        None => String::new(),
+    }
+}
+
+/*
+The bindings that the file changes through a field or a table function.
+
+`t.x = 1` and `table.insert(t, 1)` leave the binding itself alone, so the
+resolver records no write for either. A project that wants a mutated table to
+keep `local` needs them found, and this is the walk that finds them.
+*/
+fn mutated_bindings(ctx: &LintCtx<'_>) -> std::collections::HashSet<usize> {
+    let mut out = std::collections::HashSet::new();
+
+    let mut mark = |root: Option<TokSpan>| {
+        if let Some(span) = root
+            && let Some(&index) = ctx.names.read_of.get(&span.start)
+        {
+            out.insert(index);
+        }
+    };
+
+    for stmt in &ctx.stmts {
+        let Stmt::Assign(n) = stmt else {
+            continue;
+        };
+
+        // `t.x = 1`, `t[k] = v`, `t.a.b = 2`, and the compound forms of each.
+        for target in &n.targets {
+            if matches!(target, Expr::Index { .. }) {
+                mark(root_name(target));
+            }
+        }
+    }
+
+    for expr in &ctx.exprs {
+        let Expr::Call { func, args, .. } = expr else {
+            continue;
+        };
+
+        if !is_table_mutator(ctx, func) {
+            continue;
+        }
+
+        let CallArgs::Paren(list) = args else {
+            continue;
+        };
+
+        // The table these functions change is always the first argument.
+        if let Some(Expr::Name(name)) = list.first() {
+            mark(Some(*name));
+        }
+    }
+
+    out
+}
+
+/// The name an index chain starts from: `t` in `t.a.b[c]`.
+fn root_name(e: &Expr) -> Option<TokSpan> {
+    match e {
+        Expr::Name(span) => Some(*span),
+
+        Expr::Index { object, .. } => root_name(object),
+
+        _ => None,
+    }
+}
+
+/// Reports if this callee is one of the `table` functions that changes its first argument.
+fn is_table_mutator(ctx: &LintCtx<'_>, func: &Expr) -> bool {
+    let Expr::Index {
+        object,
+        key: IndexKey::Field(name),
+        ..
+    } = func
+    else {
+        return false;
+    };
+
+    let Expr::Name(base) = object.as_ref() else {
+        return false;
+    };
+
+    ctx.text(*base) == "table"
+        && matches!(
+            ctx.text(*name),
+            "insert" | "remove" | "sort" | "clear" | "move"
+        )
 }

--- a/crates/larvae/src/lint/lints/mod.rs
+++ b/crates/larvae/src/lint/lints/mod.rs
@@ -64,6 +64,7 @@ pub static ALL: &[&dyn Lint] = &[
     &configured::RestrictedModulePaths,
     &configured::HighCyclomaticComplexity,
     &configured::ManualTableClone,
+    &configured::PreferConst,
     // Roblox data types.
     &roblox::RobloxIncorrectColor3NewBounds,
     &roblox::RobloxSuspiciousUdim2New,

--- a/crates/larvae/src/lsp/extend.rs
+++ b/crates/larvae/src/lsp/extend.rs
@@ -1,0 +1,105 @@
+/*!
+The two paths a worm will reach the editor through.
+
+Neither one carries anything yet. This module is the seam, so that the work
+which fills it changes one file and not the dispatch loop, the capability
+list, and the tests all at once.
+
+**Code actions.** `textDocument/codeAction` is where a worm will offer a fix
+for a finding it reported, or a rewrite it knows how to make. Larvae already
+routes a claimed file to its worm for formatting and linting, so the worm that
+found the problem is the one that can repair it. The host owns the protocol
+and the worm owns the edit, which is the split every other capability uses.
+
+**Definitions.** A worm that teaches larvae a new kind of module has to tell
+the type system what that module is. A worm that makes a data file requirable
+is the case that asks for this: `require("./items.json")` has a type, the worm
+is what knows it, and nothing in larvae or in luau-lsp can work it out alone.
+The path is Luau definition text, because that is what luau-lsp already reads.
+`larvae worm types` writes the definitions for the worm API itself, which is a
+different file for a different reader; these are definitions for the code of
+the project.
+
+Both functions take the pool so the signature does not change when the calls
+to the worms arrive.
+*/
+
+use serde_json::{Value, json};
+
+use crate::worm::pool::Pool;
+
+/// One worm's contribution to the types of a project.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Definitions {
+    /// The worm that supplied it, for a message that names a source.
+    pub worm: String,
+    /// Luau definition text, as luau-lsp reads it.
+    pub text: String,
+}
+
+/*
+The actions a worm offers over this range.
+
+Empty until the worms answer. The shape is the LSP one, a list of `CodeAction`
+objects, and the caller sends it as the result of the request.
+
+The filled version asks each worm that claims this file for the actions it has
+over the range, and stamps the name of the worm into the title, so a user sees
+which extension offered the fix.
+*/
+pub fn code_actions(_worms: &Pool, _uri: &str, _text: &str, _range: &Value) -> Vec<Value> {
+    Vec::new()
+}
+
+/*
+The type definitions the worms of this project supply.
+
+Empty until the worms answer. The filled version asks each worm for the
+definition text it wants in scope, and the caller hands the list to the editor
+or writes it beside the project for luau-lsp to read.
+*/
+pub fn definitions(_worms: &Pool) -> Vec<Definitions> {
+    Vec::new()
+}
+
+/// The definitions as the custom request reports them.
+pub fn definitions_reply(worms: &Pool) -> Value {
+    let supplied: Vec<Value> = definitions(worms)
+        .into_iter()
+        .map(|d| json!({ "worm": d.worm, "text": d.text }))
+        .collect();
+
+    json!({ "definitions": supplied })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lsp::state::no_worms;
+
+    /*
+    The seam answers, and it answers with the right shape.
+
+    A request that errors and a request that returns nothing look the same to
+    a user and are not the same to an editor. These say that the path is
+    wired before anything travels down it.
+    */
+    #[test]
+    fn the_code_action_path_answers_with_a_list() {
+        assert_eq!(
+            code_actions(&no_worms(), "file:///t.luau", "local x = 1\n", &json!(null)),
+            Vec::<Value>::new()
+        );
+    }
+
+    #[test]
+    fn the_definitions_path_answers_with_a_list() {
+        let reply = definitions_reply(&no_worms());
+
+        assert!(
+            reply["definitions"].is_array(),
+            "an editor reads this as a list: {reply}"
+        );
+        assert_eq!(reply["definitions"].as_array().unwrap().len(), 0);
+    }
+}

--- a/crates/larvae/src/lsp/mod.rs
+++ b/crates/larvae/src/lsp/mod.rs
@@ -24,6 +24,7 @@ the Luau parser reads the first markup character and reports a syntax error.
 pub mod rpc;
 
 mod diagnostics;
+pub mod extend;
 mod features;
 mod state;
 #[cfg(test)]
@@ -203,6 +204,38 @@ impl Server {
                 self.reply(message, out, symbols)?;
             }
 
+            /*
+            The worms have nothing to offer here yet, so the reply is an
+            empty list. An empty list and an error read the same to a user
+            and are not the same to an editor: the error puts a failure in
+            the log on every keystroke that opens the lightbulb.
+            */
+            "textDocument/codeAction" => {
+                self.refresh_worms();
+
+                let uri = uri_of(&message.params);
+                let text = self.documents.get(&uri).cloned().unwrap_or_default();
+                let range = message.params["range"].clone();
+
+                let actions = extend::code_actions(&self.worms, &uri, &text, &range);
+
+                self.reply(message, out, Value::Array(actions))?;
+            }
+
+            /*
+            A request of larvae's own, under its own name, because no method
+            in the protocol carries this. A worm that teaches larvae a new
+            kind of module supplies the type of that module, and an editor
+            that wants those types asks here.
+            */
+            "larvae/definitions" => {
+                self.refresh_worms();
+
+                let reply = extend::definitions_reply(&self.worms);
+
+                self.reply(message, out, reply)?;
+            }
+
             // All other methods get an answer only if the message expects one.
             _ => {
                 if let Some(id) = &message.id {
@@ -232,6 +265,13 @@ fn capabilities() -> Value {
             "textDocumentSync": { "openClose": true, "change": 1, "save": true },
             "documentFormattingProvider": true,
             "documentSymbolProvider": true,
+            /*
+            A worm will offer the actions. Larvae advertises the capability
+            now and answers with an empty list, because an editor decides at
+            initialize whether to ever ask, and a capability that appears
+            later needs the client to be told and to agree to re register.
+            */
+            "codeActionProvider": true,
         },
         "serverInfo": { "name": "larvae", "version": env!("CARGO_PKG_VERSION") },
     })

--- a/crates/larvae/src/lsp/tests.rs
+++ b/crates/larvae/src/lsp/tests.rs
@@ -16,7 +16,60 @@ fn the_advertised_capabilities_are_all_implemented() {
 
     assert_eq!(caps["documentFormattingProvider"], true);
     assert_eq!(caps["documentSymbolProvider"], true);
+    assert_eq!(caps["codeActionProvider"], true);
     assert_eq!(caps["textDocumentSync"]["change"], 1, "full sync");
+}
+
+/*
+The two worm paths answer, and they answer with the shape an editor expects.
+
+Neither carries anything yet. What these hold is that the path is wired: a
+request that errors and a request that returns nothing look the same to a
+user and are not the same to an editor, which logs a failure on every
+keystroke that opens the lightbulb.
+*/
+#[test]
+fn a_code_action_request_answers_with_a_list() {
+    let mut server = server_with("local x = 1\n");
+    let mut out = Vec::new();
+
+    let message = message(
+        "textDocument/codeAction",
+        Some(7),
+        json!({
+            "textDocument": { "uri": "file:///t.luau" },
+            "range": {
+                "start": { "line": 0, "character": 0 },
+                "end": { "line": 0, "character": 5 }
+            },
+            "context": { "diagnostics": [] }
+        }),
+    );
+
+    server.handle(&message, &mut out).unwrap();
+
+    let text = String::from_utf8(out).unwrap();
+
+    assert!(text.contains("\"result\":[]"), "{text}");
+    assert!(
+        !text.contains("error"),
+        "an editor must not see a failure: {text}"
+    );
+}
+
+#[test]
+fn a_definitions_request_answers_with_a_list() {
+    let mut server = server_with("local x = 1\n");
+    let mut out = Vec::new();
+
+    let message = message("larvae/definitions", Some(8), json!({}));
+
+    server.handle(&message, &mut out).unwrap();
+
+    let text = String::from_utf8(out).unwrap();
+
+    assert!(text.contains("definitions"), "{text}");
+    assert!(!text.contains("is not supported"), "{text}");
 }
 
 #[test]

--- a/crates/larvae/tests/lint.rs
+++ b/crates/larvae/tests/lint.rs
@@ -1820,3 +1820,137 @@ fn a_fmt_marker_does_not_hold_the_linter() {
         1
     );
 }
+
+// --- prefer_const -----------------------------------------------------------
+
+fn prefer_const(mutated_tables_stay_local: bool) -> LintConfig {
+    let mut cfg = with("prefer_const", Level::Warn);
+
+    if mutated_tables_stay_local {
+        cfg.options.insert(
+            "prefer_const".to_string(),
+            toml::from_str("mutated_tables_stay_local = true").expect("the option parses"),
+        );
+    }
+
+    cfg
+}
+
+fn const_findings(src: &str, mutated_tables_stay_local: bool) -> usize {
+    fired(src, &prefer_const(mutated_tables_stay_local))
+        .iter()
+        .filter(|n| *n == "prefer_const")
+        .count()
+}
+
+/*
+The lint is off by default.
+
+`const` is larvae's own reading of Luau, and a codebase of ordinary `local`
+would report on nearly every line the first time it ran.
+*/
+#[test]
+fn prefer_const_says_nothing_until_a_project_asks() {
+    assert!(!fires("prefer_const", "local x = 1\nreturn x\n"));
+}
+
+#[test]
+fn a_local_that_nothing_reassigns_is_reported() {
+    assert_eq!(const_findings("local x = 1\nreturn x\n", false), 1);
+}
+
+#[test]
+fn a_local_that_something_reassigns_is_left_alone() {
+    assert_eq!(const_findings("local x = 1\nx = 2\nreturn x\n", false), 0);
+}
+
+/*
+Three forms cannot take `const`, and each would be a syntax error or has no
+`local` to change.
+*/
+#[test]
+fn the_forms_that_cannot_take_const_are_left_alone() {
+    // "Missing initializer in const declaration"
+    assert_eq!(const_findings("local x\nreturn x\n", false), 0);
+
+    assert_eq!(const_findings("const x = 1\nreturn x\n", false), 0);
+
+    assert_eq!(
+        const_findings("local function f() end\nreturn f\n", false),
+        0
+    );
+
+    assert_eq!(const_findings("for i = 1, 3 do print(i) end\n", false), 0);
+}
+
+/*
+`const` binds the declaration and not one name inside it.
+
+So `local a, b = 1, 2` where only `b` changes cannot become `const`, and the
+lint reports the statement only when every name in it qualifies.
+*/
+#[test]
+fn a_multi_name_local_reports_only_when_every_name_qualifies() {
+    assert_eq!(const_findings("local a, b = 1, 2\nreturn a, b\n", false), 1);
+    assert_eq!(
+        const_findings("local a, b = 1, 2\nb = 3\nreturn a, b\n", false),
+        0
+    );
+}
+
+/*
+A mutated table reports like any other binding by default.
+
+Luau enforces `const` against reassignment of the name and says nothing about
+the value, so `const t = {}` then `t.x = 1` compiles.
+*/
+#[test]
+fn a_mutated_table_reports_by_default() {
+    assert_eq!(
+        const_findings("local t = {}\nt.x = 1\nreturn t\n", false),
+        1
+    );
+    assert_eq!(
+        const_findings("local t = {}\ntable.insert(t, 1)\nreturn t\n", false),
+        1
+    );
+}
+
+/// The option is for a project that reads `local` as "this one changes".
+#[test]
+fn the_option_keeps_local_on_a_mutated_table() {
+    for src in [
+        "local t = {}\nt.x = 1\nreturn t\n",
+        "local t = {}\nt.a.b = 1\nreturn t\n",
+        "local t = {}\nt[key] = 1\nreturn t\n",
+        "local t = {}\nt.n += 1\nreturn t\n",
+        "local t = {}\ntable.insert(t, 1)\nreturn t\n",
+        "local t = {}\ntable.sort(t)\nreturn t\n",
+    ] {
+        assert_eq!(const_findings(src, true), 0, "{src:?}");
+    }
+}
+
+/*
+The option covers a mutation and nothing else.
+
+`table.freeze` returns a frozen copy and changes nothing, and a binding that
+holds no table was never in scope for the option.
+*/
+#[test]
+fn the_option_leaves_everything_else_reporting() {
+    assert_eq!(
+        const_findings("local t = {}\ntable.freeze(t)\nreturn t\n", true),
+        1
+    );
+    assert_eq!(const_findings("local n = 5\nreturn n\n", true), 1);
+}
+
+/// A read of a field is not a mutation of it.
+#[test]
+fn reading_a_field_is_not_mutating_it() {
+    assert_eq!(
+        const_findings("local t = {}\nprint(t.x)\nreturn t\n", true),
+        1
+    );
+}


### PR DESCRIPTION
Create a prefer_const linting rule that triggers when a variable is local but never reassigned.