### PR TITLE
Lint groups, an info level, and eleven lints for the shapes Biome catches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Notable changes land here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versions follow
 [semver](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.6.0 - 2026-08-21
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ Notable changes land here. Format follows
   the opinion changes a file. Every other default is either stylua's or a
   setting that does nothing until a project asks for it, so `recommended` does
   not move it
+- Eleven lints, mostly Luau equivalents of Biome rules. Four fill real gaps
+  that Luau's own linter reports on none of, checked against luau-lsp:
+  `length_as_condition` (deny), `builtin_shadowed`, `ignored_pcall_result` and
+  `constant_condition`. Two report a conditional used as a value, both allow:
+  `and_or_conditional` and `if_expression_assignment`. Three report the shape
+  of a branch, all allow: `else_after_return`, `collapsible_if` and
+  `negated_condition`. And two more: `implicit_any_parameter` (allow, the
+  sibling of `implicit_any_local` on the other side of the call) and
+  `restricted_globals` (silent until `[lint.options.restricted_globals]` names
+  one, so it costs nothing until a project asks)
 - `[lint.groups]`, a level for a whole kind of lint at once: `correctness`,
   `suspicious`, `style`, `complexity`, `performance` and `roblox`. It sits
   between `recommended` and `[lint.rules]`, so a name the project wrote always
@@ -55,8 +65,16 @@ Notable changes land here. Format follows
 
 ### Changed
 
-- Four lints deny by default now: `duplicate_keys`, `duplicate_local`,
-  `format_string` and `zero_step_loop`. They join `undefined_variable`. The bar
+- `misleading_and_or` reaches a middle that syntax proves is a boolean. It
+  fired only on a literal `false` or `nil`, but `ready and (count == 0) or
+  "pending"` gives "pending" when the count is not zero, which is exactly when
+  the author wanted `false`. A comparison yields a boolean because it is a
+  comparison, so the wider net needs no types. The two cases carry different
+  messages: the literal is wrong for every input and the boolean is wrong for
+  half of them
+- Five lints deny by default now: `duplicate_keys`, `duplicate_local`,
+  `format_string`, `zero_step_loop` and `length_as_condition`. They join
+  `undefined_variable`. The bar
   is two things at once: no reading of the code makes the finding wrong,
   because each check reads a literal and never a runtime value, and the code as
   written cannot be what the author meant. `{ a = 1, a = 2 }` discards the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ Notable changes land here. Format follows
   the opinion changes a file. Every other default is either stylua's or a
   setting that does nothing until a project asks for it, so `recommended` does
   not move it
+- `[lint.groups]`, a level for a whole kind of lint at once: `correctness`,
+  `suspicious`, `style`, `complexity`, `performance` and `roblox`. It sits
+  between `recommended` and `[lint.rules]`, so a name the project wrote always
+  wins and a group covers every lint it did not name. Two rules are worth
+  knowing. The table is separate from `[lint.rules]` and not nested inside it,
+  because a table there already means the lints of a worm of that name and
+  nothing reserves a worm name. And a group does not wake a lint that is
+  `allow` on purpose: `style = "info"` asks the style lints a project already
+  sees to say less, and `prefer_const` stays off until the project names it
+- `info`, a level below `warn`. It reports and it leaves the exit code alone,
+  exactly as `warn` does. The two differ in what they ask of the reader, and an
+  editor draws an info as a hint and a warning as a squiggle. The summary line
+  counts them separately, and only when a project uses the level
+- `larvae lint --explain <name>` prints the group of a lint, and the list it
+  prints when a name misses is grouped rather than one alphabetical run of 52
+- `larvae init` writes `recommended = true` into `[fmt]` and `[lint]`. The
+  value is the default already; the key is the point. A key that is there can
+  be turned off, and a key that is absent has to be found in the docs first
 - `[lint] recommended`, as Biome has it. Absent and `true` both mean the
   default levels apply, which is what larvae always did. `false` starts every
   lint at `allow`, so a project gets the lints it names and no others. A level

--- a/crates/larvae/larvae.schema.json
+++ b/crates/larvae/larvae.schema.json
@@ -1200,6 +1200,9 @@
           ],
           "description": "Whether a lint larvae recommends is on without this project saying so. Absent and `true` both mean the default levels apply. `false` starts every lint at `allow`, so the project gets the lints it names under `[lint.rules]` and no others. A level the project wrote always wins in either state."
         },
+        "groups": {
+          "$ref": "#/$defs/lint_groups"
+        },
         "std": {
           "default": "roblox",
           "description": "Which globals exist before a file runs. Anything else is undefined_variable.",
@@ -1254,10 +1257,11 @@
     "lint_level": {
       "enum": [
         "allow",
+        "info",
         "warn",
         "deny"
       ],
-      "description": "\"allow\" is off, \"warn\" is reported and leaves the exit code alone, \"deny\" is reported and fails the run."
+      "description": "\"allow\" is off. \"info\" and \"warn\" are both reported and both leave the exit code alone; they differ in what they ask of the reader, and an editor draws an info as a hint and a warning as a squiggle. \"deny\" is reported and fails the run."
     },
     "lint_rules": {
       "description": "How loudly each lint speaks. A lint keeps its own default until it is named here. A name not listed below is a worm's lint, declared in that worm's [lints] and levelled here the same way.",
@@ -1980,6 +1984,37 @@
           },
           "description": "Extra entry points, as paths relative to the project root. A module in this list is never reported as unused.",
           "default": []
+        }
+      }
+    },
+    "lint_groups": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "A level for a whole kind of lint. It sits between `recommended` and [lint.rules]: a name in [lint.rules] always wins, and a group covers every lint the project did not name. Groups live here and not inside [lint.rules], because a table there already means the lints of a worm of that name.",
+      "properties": {
+        "correctness": {
+          "$ref": "#/$defs/lint_level",
+          "description": "The code cannot do what it says: it throws, it hangs, or a line of it is dead. Every lint of this kind that [lint.rules] does not name takes this level."
+        },
+        "suspicious": {
+          "$ref": "#/$defs/lint_level",
+          "description": "Probably wrong, and a human decides. Every lint of this kind that [lint.rules] does not name takes this level."
+        },
+        "style": {
+          "$ref": "#/$defs/lint_level",
+          "description": "A matter of how the code reads. Every lint of this kind that [lint.rules] does not name takes this level."
+        },
+        "complexity": {
+          "$ref": "#/$defs/lint_level",
+          "description": "More shape than the job needs. Every lint of this kind that [lint.rules] does not name takes this level."
+        },
+        "performance": {
+          "$ref": "#/$defs/lint_level",
+          "description": "Correct, and it costs more than it has to. Every lint of this kind that [lint.rules] does not name takes this level."
+        },
+        "roblox": {
+          "$ref": "#/$defs/lint_level",
+          "description": "A Roblox data type used in a way that does not hold. Every lint of this kind that [lint.rules] does not name takes this level."
         }
       }
     }

--- a/crates/larvae/larvae.schema.json
+++ b/crates/larvae/larvae.schema.json
@@ -1277,382 +1277,124 @@
         "almost_swapped": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
           "description": "Two assignments that look like a swap but overwrite one of the values. Default: warn."
         },
-        "compare_nan": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "Comparing against nan, which is never equal to anything including itself. Default: warn."
-        },
-        "constant_table_comparison": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "Comparing against a table literal, which compares identity and is always false. Default: warn."
-        },
-        "divide_by_zero": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "Dividing by a literal zero. Default: warn."
-        },
-        "duplicate_keys": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A table key written twice, where only the last one survives. Default: warn."
-        },
-        "ifs_same_cond": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "An elseif repeating a condition already tested, which can never run. Default: warn."
-        },
-        "if_same_then_else": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "Two branches of the same if with identical bodies. Default: warn."
-        },
-        "implicit_any_local": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A local declared with no value and no type, so what it holds is decided by whatever assigns it first. In a file with no `--!strict` directive Luau accepts any later assignment of any type, which is the implicit `any` this names. A local that nothing ever assigns is left to `uninitialized_local`, which says the more urgent thing about the same line. The only lint larvae denies by default, because the fix is an annotation and an annotation changes no behaviour. Default: deny."
-        },
-        "prefer_const": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A local that nothing reassigns, which `const` states outright. Off by default: `const` is larvae's own reading of Luau and not every project writes it, so a codebase of ordinary `local` would report on nearly every line the first time it ran. Tune it under [lint.options.prefer_const]. Default: allow."
-        },
-        "suspicious_reverse_loop": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A numeric for counting down without a negative step, which never runs. Default: warn."
-        },
-        "type_check_inside_call": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A comparison inside type(), where it belongs outside. Default: warn."
-        },
-        "unbalanced_assignments": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "More names than values, or more values than names. Default: warn."
-        },
-        "zero_step_loop": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A numeric for whose step is zero, so the counter never moves. Default: warn."
-        },
-        "bad_string_escape": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "An escape sequence the language does not define. Default: warn."
-        },
-        "mismatched_arg_count": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "Calling a function in this file with the wrong number of arguments. Default: warn."
-        },
-        "must_use": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "Calling a pure function and discarding what it returned. Default: warn."
-        },
         "bad_comment_directive": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
           "description": "A --! directive that Luau does not know, or one that comes after the code it should govern. Default: warn."
         },
+        "bad_string_escape": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "An escape sequence the language does not define. Default: warn."
+        },
         "builtin_global_write": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
           "description": "An assignment over a standard global, which every later script sees. Default: warn."
         },
+        "builtin_shadowed": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A local that takes the name of a standard global, such as `local table = {}`. The library is unreachable for the rest of the scope, and the failure lands at the first line that wanted it. Default: warn."
+        },
+        "compare_nan": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Comparing against nan, which is never equal to anything including itself. Default: warn."
+        },
         "comparison_precedence": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
           "description": "not a == b, or a chain like a < b < c, which does not group the way it reads. Default: warn."
         },
-        "duplicate_function": {
+        "constant_table_comparison": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
-          "description": "Two functions of the same name in one scope, where the first is discarded. Default: warn."
-        },
-        "duplicate_local": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "One local statement or parameter list that declares the same name twice. Default: warn."
-        },
-        "format_string": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A format string that string.format or os.date rejects at runtime. Default: warn."
-        },
-        "implicit_return": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A function that returns a value on one path and falls off the end on another. The lint is off by default, because a lookup that returns nil when it finds nothing is idiomatic Luau. Default: warn."
-        },
-        "misleading_and_or": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "cond and false or b, which always gives b because the middle is never truthy. Default: warn."
-        },
-        "number_literal_overflow": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A hexadecimal or binary literal wider than 64 bits, which is truncated. Default: warn."
-        },
-        "placeholder_read": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "Reading _, the name that says a value is discarded. Default: warn."
-        },
-        "table_operations": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A table.insert or table.remove whose index or argument count is wrong. Default: warn."
-        },
-        "uninitialized_local": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A local declared with no value and never assigned, so every read is nil. Default: warn."
-        },
-        "unknown_type": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "Comparing type(x) against a string that type() never returns. Default: warn."
-        },
-        "undefined_variable": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A name nothing declares, which is nil at runtime. Default: deny."
-        },
-        "unscoped_variables": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "An assignment with no local, which creates a global. Default: warn."
-        },
-        "unused_function": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A `local function` that nothing calls. The Luau compiler separates this from an unused variable and separates it by the declaring form, so `local f = function() end` is `unused_variable` and `local function f() end` is this. Both read [lint.options.unused_variable]. Default: warn."
-        },
-        "unused_variable": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A name declared and never read. Default: warn. Tunable under [lint.options.unused_variable]."
-        },
-        "shadowing": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A name that hides another still in scope. Default: warn."
-        },
-        "global_usage": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "Reaching into _G, which is shared with every other script. Default: warn."
+          "description": "Comparing against a table literal, which compares identity and is always false. Default: warn."
         },
         "deprecated": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
           "description": "A function that still works but has been replaced. Default: warn. Extend it under [lint.options.deprecated]."
         },
-        "restricted_module_paths": {
+        "divide_by_zero": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
-          "description": "Requiring a module the project has ruled out. Default: warn, and quiet until [lint.options.restricted_module_paths] names something."
+          "description": "Dividing by a literal zero. Default: warn."
         },
-        "high_cyclomatic_complexity": {
+        "duplicate_function": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
-          "description": "A function with more branches than anyone can hold at once. Default: allow. Threshold under [lint.options.high_cyclomatic_complexity]."
+          "description": "Two functions of the same name in one scope, where the first is discarded. Default: warn."
         },
-        "manual_table_clone": {
+        "duplicate_keys": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
-          "description": "A loop that copies a table, which table.clone does in one call. Default: warn."
+          "description": "A table key written twice, where only the last one survives. Default: warn."
         },
-        "roblox_incorrect_color3_new_bounds": {
+        "duplicate_local": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
-          "description": "Color3.new given a channel over 1, where the scale is 0 to 1. Default: warn."
-        },
-        "roblox_suspicious_udim2_new": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "UDim2.new given two arguments, where it takes four. Default: warn."
-        },
-        "roblox_manual_fromscale_or_fromoffset": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A UDim2.new that fromScale or fromOffset says more clearly. Default: warn."
-        },
-        "non_const_require": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A required module bound with local, where const says it never changes. The lint skips a name that the file reassigns, because const would then be a syntax error. Default: allow."
-        },
-        "unreachable_code": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "Statements after a return, break or continue, which never run. Default: warn."
-        },
-        "self_assignment": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "Assigning a value to itself, which does nothing. Default: warn."
-        },
-        "string_concat_in_loop": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "Building a string by concatenation in a loop, which is quadratic. Default: warn."
-        },
-        "loop_invariant_call": {
-          "enum": [
-            "allow",
-            "warn",
-            "deny"
-          ],
-          "description": "A call inside a loop whose result cannot change between iterations. Default: warn."
+          "description": "One local statement or parameter list that declares the same name twice. Default: warn."
         },
         "empty_if": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
@@ -1661,14 +1403,133 @@
         "empty_loop": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
           "description": "A loop body with nothing in it. Default: warn."
         },
+        "format_string": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A format string that string.format or os.date rejects at runtime. Default: warn."
+        },
+        "global_usage": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Reaching into _G, which is shared with every other script. Default: warn."
+        },
+        "high_cyclomatic_complexity": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A function with more branches than anyone can hold at once. Default: allow. Threshold under [lint.options.high_cyclomatic_complexity]."
+        },
+        "if_same_then_else": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Two branches of the same if with identical bodies. Default: warn."
+        },
+        "ifs_same_cond": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "An elseif repeating a condition already tested, which can never run. Default: warn."
+        },
+        "ignored_pcall_result": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A pcall or xpcall used as a statement. It catches the error and discards it, so the failure leaves no trace at all. Default: warn."
+        },
+        "implicit_any_local": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A local declared with no value and no type, so what it holds is decided by whatever assigns it first. In a file with no `--!strict` directive Luau accepts any later assignment of any type, which is the implicit `any` this names. A local that nothing ever assigns is left to `uninitialized_local`, which says the more urgent thing about the same line. The only lint larvae denies by default, because the fix is an annotation and an annotation changes no behaviour. Default: deny."
+        },
+        "implicit_return": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A function that returns a value on one path and falls off the end on another. The lint is off by default, because a lookup that returns nil when it finds nothing is idiomatic Luau. Default: warn."
+        },
+        "length_as_condition": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "#t used as a condition. A length is a number and every number is true in Luau, so the guard does nothing and the branch runs every time. Default: deny."
+        },
+        "loop_invariant_call": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A call inside a loop whose result cannot change between iterations. Default: warn."
+        },
+        "manual_table_clone": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A loop that copies a table, which table.clone does in one call. Default: warn."
+        },
+        "misleading_and_or": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "cond and false or b, which always gives b because the middle is never truthy. Default: warn."
+        },
+        "mismatched_arg_count": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Calling a function in this file with the wrong number of arguments. Default: warn."
+        },
         "mixed_table": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
@@ -1677,18 +1538,236 @@
         "multiple_statements": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
           "description": "More than one statement on a line. Default: warn."
         },
+        "must_use": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Calling a pure function and discarding what it returned. Default: warn."
+        },
+        "non_const_require": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A required module bound with local, where const says it never changes. The lint skips a name that the file reassigns, because const would then be a syntax error. Default: allow."
+        },
+        "number_literal_overflow": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A hexadecimal or binary literal wider than 64 bits, which is truncated. Default: warn."
+        },
         "parenthese_conditions": {
           "enum": [
             "allow",
+            "info",
             "warn",
             "deny"
           ],
           "description": "Parentheses around a condition, which Luau does not need. Default: warn."
+        },
+        "placeholder_read": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Reading _, the name that says a value is discarded. Default: warn."
+        },
+        "prefer_const": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A local that nothing reassigns, which `const` states outright. Off by default: `const` is larvae's own reading of Luau and not every project writes it, so a codebase of ordinary `local` would report on nearly every line the first time it ran. Tune it under [lint.options.prefer_const]. Default: allow."
+        },
+        "restricted_module_paths": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Requiring a module the project has ruled out. Default: warn, and quiet until [lint.options.restricted_module_paths] names something."
+        },
+        "roblox_incorrect_color3_new_bounds": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Color3.new given a channel over 1, where the scale is 0 to 1. Default: warn."
+        },
+        "roblox_manual_fromscale_or_fromoffset": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A UDim2.new that fromScale or fromOffset says more clearly. Default: warn."
+        },
+        "roblox_suspicious_udim2_new": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "UDim2.new given two arguments, where it takes four. Default: warn."
+        },
+        "self_assignment": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Assigning a value to itself, which does nothing. Default: warn."
+        },
+        "shadowing": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A name that hides another still in scope. Default: warn."
+        },
+        "string_concat_in_loop": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Building a string by concatenation in a loop, which is quadratic. Default: warn."
+        },
+        "suspicious_reverse_loop": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A numeric for counting down without a negative step, which never runs. Default: warn."
+        },
+        "table_operations": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A table.insert or table.remove whose index or argument count is wrong. Default: warn."
+        },
+        "type_check_inside_call": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A comparison inside type(), where it belongs outside. Default: warn."
+        },
+        "unbalanced_assignments": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "More names than values, or more values than names. Default: warn."
+        },
+        "undefined_variable": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A name nothing declares, which is nil at runtime. Default: deny."
+        },
+        "uninitialized_local": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A local declared with no value and never assigned, so every read is nil. Default: warn."
+        },
+        "unknown_type": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Comparing type(x) against a string that type() never returns. Default: warn."
+        },
+        "unreachable_code": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Statements after a return, break or continue, which never run. Default: warn."
+        },
+        "unscoped_variables": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "An assignment with no local, which creates a global. Default: warn."
+        },
+        "unused_function": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A `local function` that nothing calls. The Luau compiler separates this from an unused variable and separates it by the declaring form, so `local f = function() end` is `unused_variable` and `local function f() end` is this. Both read [lint.options.unused_variable]. Default: warn."
+        },
+        "unused_variable": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A name declared and never read. Default: warn. Tunable under [lint.options.unused_variable]."
+        },
+        "zero_step_loop": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A numeric for whose step is zero, so the counter never moves. Default: warn."
         }
       }
     },

--- a/crates/larvae/larvae.schema.json
+++ b/crates/larvae/larvae.schema.json
@@ -1283,6 +1283,15 @@
           ],
           "description": "Two assignments that look like a swap but overwrite one of the values. Default: warn."
         },
+        "and_or_conditional": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "`cond and a or b` used as a value. The decision hides inside an expression, where an if statement states one case per branch. Off by default: the form is ordinary Lua and it is correct for every truthy middle. Default: allow."
+        },
         "bad_comment_directive": {
           "enum": [
             "allow",
@@ -1319,6 +1328,15 @@
           ],
           "description": "A local that takes the name of a standard global, such as `local table = {}`. The library is unreachable for the rest of the scope, and the failure lands at the first line that wanted it. Default: warn."
         },
+        "collapsible_if": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "An if that holds one if and nothing else. The two conditions are one `and` apart, and the nesting says they are not. Default: allow."
+        },
         "compare_nan": {
           "enum": [
             "allow",
@@ -1336,6 +1354,15 @@
             "deny"
           ],
           "description": "not a == b, or a chain like a < b < c, which does not group the way it reads. Default: warn."
+        },
+        "constant_condition": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A condition that is a literal, so the branch is decided before the program runs. Only nil and false are false in Luau, so `if 0 then` and `if \"\" then` both pass. `while true do` and `repeat ... until false` are exempt, because both are standard loops. Default: warn."
         },
         "constant_table_comparison": {
           "enum": [
@@ -1391,6 +1418,15 @@
           ],
           "description": "One local statement or parameter list that declares the same name twice. Default: warn."
         },
+        "else_after_return": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "An else after a branch that returns, breaks or continues. The else costs a level of indent and buys nothing. Every branch must end in the jump, because an elseif that falls through still needs the else. Default: allow."
+        },
         "empty_if": {
           "enum": [
             "allow",
@@ -1436,6 +1472,15 @@
           ],
           "description": "A function with more branches than anyone can hold at once. Default: allow. Threshold under [lint.options.high_cyclomatic_complexity]."
         },
+        "if_expression_assignment": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "`if cond then a else b` used as a value. Off by default, and it has to stay off: misleading_and_or names this exact form as the repair, so a default that reported would report the fix larvae asked for. Default: allow."
+        },
         "if_same_then_else": {
           "enum": [
             "allow",
@@ -1471,6 +1516,15 @@
             "deny"
           ],
           "description": "A local declared with no value and no type, so what it holds is decided by whatever assigns it first. In a file with no `--!strict` directive Luau accepts any later assignment of any type, which is the implicit `any` this names. A local that nothing ever assigns is left to `uninitialized_local`, which says the more urgent thing about the same line. The only lint larvae denies by default, because the fix is an annotation and an annotation changes no behaviour. Default: deny."
+        },
+        "implicit_any_parameter": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "A parameter with no type, so what the function takes is decided by each caller. The sibling of implicit_any_local, on the other side of the call. Off by default: most Luau carries no annotations, so a warn default would report hundreds of times on the first run. Default: allow."
         },
         "implicit_return": {
           "enum": [
@@ -1553,6 +1607,15 @@
           ],
           "description": "Calling a pure function and discarding what it returned. Default: warn."
         },
+        "negated_condition": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "An if with a negated condition and an else. Dropping the not and swapping the bodies states the same thing in the order a reader expects. Default: allow."
+        },
         "non_const_require": {
           "enum": [
             "allow",
@@ -1597,6 +1660,15 @@
             "deny"
           ],
           "description": "A local that nothing reassigns, which `const` states outright. Off by default: `const` is larvae's own reading of Luau and not every project writes it, so a codebase of ordinary `local` would report on nearly every line the first time it ran. Tune it under [lint.options.prefer_const]. Default: allow."
+        },
+        "restricted_globals": {
+          "enum": [
+            "allow",
+            "info",
+            "warn",
+            "deny"
+          ],
+          "description": "Reading a global the project has ruled out. Silent until the project fills in [lint.options.restricted_globals], so the default level costs nothing. Each entry is a name and the reason a reader is shown. Default: warn."
         },
         "restricted_module_paths": {
           "enum": [
@@ -1778,6 +1850,66 @@
         "type": "object"
       },
       "properties": {
+        "deprecated": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "additional": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Names the project has deprecated of its own, as old = \"what to use instead\"."
+            }
+          }
+        },
+        "high_cyclomatic_complexity": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "maximum_complexity": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 40,
+              "description": "Branches a function may have before it is reported. selene's default, kept so a project moving over gets the same answers."
+            }
+          }
+        },
+        "prefer_const": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "mutated_tables_stay_local": {
+              "type": "boolean",
+              "enum": [
+                true,
+                false
+              ],
+              "default": false,
+              "description": "Keep `local` on a binding the file mutates through a field, such as `t.x = 1` or `table.insert(t, 1)`. Off by default, because `const` is correct there: Luau enforces it against reassignment of the name and says nothing about the value, so `const t = {}` then `t.x = 1` compiles. Turn it on where `local` is read as \"this one changes\"."
+            }
+          }
+        },
+        "restricted_globals": {
+          "type": "object",
+          "description": "Globals this project rules out, as `name = \"why\"`. The reason is the message a reader gets, so a bare list of names would report \"this is restricted\" and leave them guessing.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "restricted_module_paths": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "paths": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Require paths the project forbids, as path = \"why\"."
+            }
+          }
+        },
         "unused_variable": {
           "type": "object",
           "additionalProperties": false,
@@ -1804,59 +1936,6 @@
               "type": "string",
               "default": "^_",
               "description": "Names exempted, as a regular expression."
-            }
-          }
-        },
-        "high_cyclomatic_complexity": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "maximum_complexity": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 40,
-              "description": "Branches a function may have before it is reported. selene's default, kept so a project moving over gets the same answers."
-            }
-          }
-        },
-        "deprecated": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "additional": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              },
-              "description": "Names the project has deprecated of its own, as old = \"what to use instead\"."
-            }
-          }
-        },
-        "restricted_module_paths": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "paths": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              },
-              "description": "Require paths the project forbids, as path = \"why\"."
-            }
-          }
-        },
-        "prefer_const": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "mutated_tables_stay_local": {
-              "type": "boolean",
-              "enum": [
-                true,
-                false
-              ],
-              "default": false,
-              "description": "Keep `local` on a binding the file mutates through a field, such as `t.x = 1` or `table.insert(t, 1)`. Off by default, because `const` is correct there: Luau enforces it against reassignment of the name and says nothing about the value, so `const t = {}` then `t.x = 1` compiles. Turn it on where `local` is read as \"this one changes\"."
             }
           }
         }

--- a/crates/larvae/src/commands/init.rs
+++ b/crates/larvae/src/commands/init.rs
@@ -149,7 +149,14 @@ fn fmt_section(root: &Path) -> String {
              # A [fmt] table here would layer over it.\n"
         ),
 
-        None => format!("\n[fmt]\n{}", fmt_defaults()),
+        /*
+        `recommended = true` is written out, though it is also the default.
+
+        The value is not the point; the key is. A new project reads the file
+        it was given, and a key that is there can be turned off. A key that
+        is absent has to be found in the docs first.
+        */
+        None => format!("\n[fmt]\nrecommended = true\n{}", fmt_defaults()),
     }
 }
 
@@ -201,8 +208,9 @@ fn lint_section(root: &Path) -> String {
              # A [lint] table here would layer over it.\n"
         ),
 
-        None => "\n[lint]\nstd = \"roblox\"\n\
-             # Set levels under [lint.rules]; `larvae lint --explain <name>` describes one.\n"
+        None => "\n[lint]\nrecommended = true\nstd = \"roblox\"\n\
+             # Set a level for one lint under [lint.rules], or for a whole kind\n\
+             # under [lint.groups]. `larvae lint --explain <name>` describes one.\n"
             .to_string(),
     }
 }
@@ -407,8 +415,38 @@ mod tests {
             toml::Value::try_from(v).unwrap()
         }
 
-        assert_eq!(value(&fmt), value(&crate::fmt::FmtConfig::default()));
-        assert_eq!(value(&lint), value(&crate::lint::LintConfig::default()));
+        /*
+        `recommended = true` is written out, and it is also the default, so
+        the two configs differ by that key alone. The comparison sets it on
+        both sides rather than skipping it: a default that ever stopped
+        meaning `true` has to fail here.
+        */
+        let fmt_default = crate::fmt::FmtConfig {
+            recommended: Some(true),
+            ..Default::default()
+        };
+
+        let lint_default = crate::lint::LintConfig {
+            recommended: Some(true),
+            ..Default::default()
+        };
+
+        assert_eq!(value(&fmt), value(&fmt_default));
+        assert_eq!(value(&lint), value(&lint_default));
+
+        // And what init wrote is what larvae does with no config at all.
+        assert_eq!(
+            fmt.magic_trailing_comma,
+            crate::fmt::FmtConfig::default().magic_trailing_comma
+        );
+        assert_eq!(
+            lint.level_for(
+                "shadowing",
+                Some(crate::lint::Group::Suspicious),
+                crate::lint::Level::Warn
+            ),
+            crate::lint::Level::Warn
+        );
     }
 
     /// A project that formats with stylua keeps its settings. The file that

--- a/crates/larvae/src/commands/lint.rs
+++ b/crates/larvae/src/commands/lint.rs
@@ -179,7 +179,12 @@ fn from_stdin(
 fn explain_lint(root: &Path, config: Option<&Path>, name: &str) -> Result<ExitCode> {
     if let Some(found) = crate::lint::find(name) {
         println!("{}\n  {}", found.name(), found.about());
-        println!("  default: {:?}", found.default_level());
+        println!("  default: {}", level_name(found.default_level()));
+        println!(
+            "  group:   {}, so [lint.groups] {} covers it",
+            found.group().name(),
+            found.group().name()
+        );
 
         return Ok(ExitCode::SUCCESS);
     }
@@ -198,23 +203,37 @@ fn explain_lint(root: &Path, config: Option<&Path>, name: &str) -> Result<ExitCo
             None => println!("  worm `{worm}` declares this lint and describes it nowhere"),
         }
 
-        println!("  default: {:?}", decl.default);
+        println!("  default: {}", level_name(decl.default));
         println!("  from:    worm `{worm}`");
 
         return Ok(ExitCode::SUCCESS);
     }
 
     ui::print_error(&format!("no lint called {name}"));
-    println!("\navailable lints:");
 
-    // The list is sorted for lookup, and the width keeps the second column aligned.
-    let mut all: Vec<_> = registry().iter().collect();
-    all.sort_by_key(|l| l.name());
+    /*
+    The list is printed by group, and each name is sorted inside its group.
 
-    let width = all.iter().map(|l| l.name().len()).max().unwrap_or(0);
+    Fifty two names in one alphabetical run is a wall. The group is also what
+    a project sets under `[lint.groups]`, so the heading is a config key and
+    not decoration.
+    */
+    let width = registry().iter().map(|l| l.name().len()).max().unwrap_or(0);
 
-    for lint in all {
-        println!("  {:<width$}  {}", lint.name(), lint.about());
+    for group in crate::lint::Group::all() {
+        let mut of_group: Vec<_> = registry().iter().filter(|l| l.group() == group).collect();
+
+        if of_group.is_empty() {
+            continue;
+        }
+
+        of_group.sort_by_key(|l| l.name());
+
+        println!("\n{}:", group.name());
+
+        for lint in of_group {
+            println!("  {:<width$}  {}", lint.name(), lint.about());
+        }
     }
 
     Ok(ExitCode::FAILURE)
@@ -295,12 +314,11 @@ fn report(diags: &[Diag], scanned: usize) -> Result<ExitCode> {
         }
     }
 
-    let errors = diags
-        .iter()
-        .filter(|d| d.severity == Severity::Error)
-        .count();
+    let count = |want: Severity| diags.iter().filter(|d| d.severity == want).count();
 
-    let warnings = diags.len() - errors;
+    let errors = count(Severity::Error);
+    let warnings = count(Severity::Warning);
+    let infos = count(Severity::Info);
 
     if diags.is_empty() {
         ui::print_success(&format!("{}, nothing to report", files(scanned)));
@@ -308,7 +326,20 @@ fn report(diags: &[Diag], scanned: usize) -> Result<ExitCode> {
         return Ok(ExitCode::SUCCESS);
     }
 
-    println!("\n{}, {errors} errors, {warnings} warnings", files(scanned));
+    /*
+    The info count joins the line only when a project uses the level. A
+    project that never writes `info` reads the summary it always read.
+    */
+    let tail = match infos {
+        0 => String::new(),
+
+        n => format!(", {n} infos"),
+    };
+
+    println!(
+        "\n{}, {errors} errors, {warnings} warnings{tail}",
+        files(scanned)
+    );
 
     /*
     Only an error fails the run. A project that wants a warning to fail CI
@@ -319,5 +350,17 @@ fn report(diags: &[Diag], scanned: usize) -> Result<ExitCode> {
         0 => Ok(ExitCode::SUCCESS),
 
         _ => Ok(ExitCode::FAILURE),
+    }
+}
+
+/// The level as a project writes it, which is not how Rust prints the enum
+fn level_name(level: crate::lint::Level) -> &'static str {
+    use crate::lint::Level;
+
+    match level {
+        Level::Allow => "allow",
+        Level::Info => "info",
+        Level::Warn => "warn",
+        Level::Deny => "deny",
     }
 }

--- a/crates/larvae/src/diag.rs
+++ b/crates/larvae/src/diag.rs
@@ -3,6 +3,15 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Severity {
+    /*
+    Worth knowing, and not worth acting on today.
+
+    It reports and it changes no exit code, exactly as a warning does. The
+    two differ in what they ask of the reader, and an editor draws them
+    apart: a warning is a squiggle, an info is a hint. A project that wants
+    a lint on the record without adding to the pile of warnings sets it here.
+    */
+    Info,
     Warning,
     Error,
 }
@@ -88,6 +97,8 @@ impl Diag {
             Severity::Error => ("✗", DEEP_FG, "error"),
 
             Severity::Warning => ("!", BRAND_FG, "warning"),
+
+            Severity::Info => ("i", DARK_FG, "info"),
         };
 
         let mut out = format!("{head_color}{BOLD}{glyph} {sev}:{RESET} {}", self.message);
@@ -107,6 +118,8 @@ impl fmt::Display for Diag {
             Severity::Error => "error",
 
             Severity::Warning => "warning",
+
+            Severity::Info => "info",
         };
 
         write!(f, "{sev}: {}", self.message)?;

--- a/crates/larvae/src/lint/config.rs
+++ b/crates/larvae/src/lint/config.rs
@@ -25,11 +25,74 @@ use crate::config::Excludes;
 pub enum Level {
     /// The lint is off.
     Allow,
+    /*
+    larvae reports the finding as an info. The exit code does not change.
+
+    It is the level below `warn` for a lint a project wants on the record
+    without adding to the pile it reads every day. An editor draws it as a
+    hint rather than a squiggle.
+    */
+    Info,
     /// larvae reports the finding. The exit code does not change.
     #[default]
     Warn,
     /// larvae reports the finding, and the run fails.
     Deny,
+}
+
+/*
+The kind of mistake a lint catches, so a project can set many at once.
+
+Biome has these, and the reason to copy them is the one Biome has: a project
+that wants every style opinion off should not have to name nine lints. The
+groups live in `[lint.groups]` and not inside `[lint.rules]`, which is not a
+matter of taste. A table under `[lint.rules]` already means the lints of a
+worm of that name, and nothing reserves a worm name, so a worm published as
+`style` would make `[lint.rules.style]` mean two things at once. A separate
+table has no such collision, and every config written before this reads
+exactly as it did.
+*/
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Group {
+    /// The code cannot do what it says.
+    Correctness,
+    /// Probably wrong, and a human decides.
+    Suspicious,
+    /// A matter of how the code reads.
+    Style,
+    /// More shape than the job needs.
+    Complexity,
+    /// Correct, and it costs more than it has to.
+    Performance,
+    /// A Roblox data type used in a way that does not hold.
+    Roblox,
+}
+
+impl Group {
+    /// The name a project writes under `[lint.groups]`
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Correctness => "correctness",
+            Self::Suspicious => "suspicious",
+            Self::Style => "style",
+            Self::Complexity => "complexity",
+            Self::Performance => "performance",
+            Self::Roblox => "roblox",
+        }
+    }
+
+    /// Every group, for the schema and for `--explain`
+    pub fn all() -> [Self; 6] {
+        [
+            Self::Correctness,
+            Self::Suspicious,
+            Self::Style,
+            Self::Complexity,
+            Self::Performance,
+            Self::Roblox,
+        ]
+    }
 }
 
 /// The set of globals that larvae checks a bare name against.
@@ -107,6 +170,17 @@ pub struct LintConfig {
     #[serde(default)]
     pub recommended: Option<bool>,
 
+    /*
+    A level for a whole group of lints.
+
+    It sits between `recommended` and `[lint.rules]`: a name in `[lint.rules]`
+    always wins, and a group covers every lint the project did not name. So
+    `style = "allow"` with `mixed_table = "warn"` is one style lint back on
+    and the rest off.
+    */
+    #[serde(default)]
+    pub groups: BTreeMap<Group, Level>,
+
     /// The level for each lint, keyed by the lint's name.
     #[serde(default, deserialize_with = "levels")]
     pub rules: BTreeMap<String, Level>,
@@ -142,13 +216,38 @@ impl LintConfig {
         self.enabled != Some(false)
     }
 
-    pub fn level_for(&self, name: &str, default: Level) -> Level {
+    /*
+    The level of one lint, most specific answer first.
+
+    A name the project wrote wins over its group, a group wins over
+    `recommended`, and `recommended` wins over the default of the lint. A
+    worm lint passes `None` for the group, because a worm declares a name and
+    not a kind.
+    */
+    pub fn level_for(&self, name: &str, group: Option<Group>, default: Level) -> Level {
         if let Some(level) = self.rules.get(name) {
             return *level;
         }
 
         /*
-        A name the project did not mention falls back to what larvae
+        A group covers the lints of its kind that report, and it does not
+        wake one that is off.
+
+        `prefer_const` is `allow` on purpose: it rewrites a keyword, and a
+        codebase of ordinary `local` would report on nearly every line. A
+        project that writes `style = "info"` is asking the style lints it
+        already sees to say less, not asking for a lint it never had. Biome
+        draws the line in the same place. To turn one on, name it in
+        `[lint.rules]`, which beats the group anyway.
+        */
+        if default != Level::Allow
+            && let Some(level) = group.and_then(|g| self.groups.get(&g))
+        {
+            return *level;
+        }
+
+        /*
+        A lint the project did not mention falls back to what larvae
         recommends, unless the project turned that off. Absent reads as
         `true`, so a config written before this option behaves as it did.
         */
@@ -210,6 +309,7 @@ impl LintConfig {
             config.recommended = over.recommended.or(config.recommended);
             config.enabled = over.enabled.or(config.enabled);
 
+            config.groups.extend(over.groups);
             config.rules.extend(over.rules);
             config.options.extend(over.options);
             config.globals.extend(over.globals);
@@ -274,6 +374,8 @@ fn selene_file(root: &Path) -> Result<Option<LintConfig>> {
         // selene has no such key, so a selene.toml states nothing about them
         recommended: None,
         enabled: None,
+        // selene has no groups either, so a selene.toml sets none
+        groups: BTreeMap::new(),
         rules: file.rules,
         options: file.config,
         std,
@@ -337,11 +439,17 @@ mod tests {
     fn a_lint_uses_its_own_default_until_the_project_says_otherwise() {
         let mut cfg = LintConfig::default();
 
-        assert_eq!(cfg.level_for("unused_variable", Level::Warn), Level::Warn);
+        assert_eq!(
+            cfg.level_for("unused_variable", None, Level::Warn),
+            Level::Warn
+        );
 
         cfg.rules.insert("unused_variable".into(), Level::Allow);
 
-        assert_eq!(cfg.level_for("unused_variable", Level::Warn), Level::Allow);
+        assert_eq!(
+            cfg.level_for("unused_variable", None, Level::Warn),
+            Level::Allow
+        );
     }
 
     #[test]
@@ -496,6 +604,109 @@ mod tests {
             LintConfig::discover(dir.path(), Some(&over))
                 .unwrap()
                 .is_enabled()
+        );
+    }
+
+    #[test]
+    fn a_group_covers_every_lint_of_its_kind() {
+        let dir = tempfile::tempdir().unwrap();
+        let over = toml::from_str::<toml::Value>("[groups]\nstyle = \"allow\"").unwrap();
+        let cfg = LintConfig::discover(dir.path(), Some(&over)).unwrap();
+
+        assert_eq!(
+            cfg.level_for("parenthese_conditions", Some(Group::Style), Level::Warn),
+            Level::Allow
+        );
+
+        // A lint of another kind is untouched.
+        assert_eq!(
+            cfg.level_for("compare_nan", Some(Group::Correctness), Level::Warn),
+            Level::Warn
+        );
+    }
+
+    #[test]
+    fn a_name_the_project_wrote_beats_its_group() {
+        let dir = tempfile::tempdir().unwrap();
+        let text = "[groups]\nstyle = \"allow\"\n\n[rules]\nmixed_table = \"deny\"";
+        let over = toml::from_str::<toml::Value>(text).unwrap();
+        let cfg = LintConfig::discover(dir.path(), Some(&over)).unwrap();
+
+        assert_eq!(
+            cfg.level_for("mixed_table", Some(Group::Style), Level::Warn),
+            Level::Deny
+        );
+    }
+
+    /*
+    A group does not wake a lint that is off on purpose.
+
+    `prefer_const` is `allow` because it rewrites a keyword. A project that
+    writes `style = "info"` asks the style lints it already sees to say less;
+    it is not asking for a lint it never had.
+    */
+    #[test]
+    fn a_group_does_not_turn_on_a_lint_that_is_allow() {
+        let dir = tempfile::tempdir().unwrap();
+        let over = toml::from_str::<toml::Value>("[groups]\nstyle = \"info\"").unwrap();
+        let cfg = LintConfig::discover(dir.path(), Some(&over)).unwrap();
+
+        assert_eq!(
+            cfg.level_for("prefer_const", Some(Group::Style), Level::Allow),
+            Level::Allow
+        );
+
+        // Naming it is how a project turns it on, and that still works.
+        let text = "[groups]\nstyle = \"info\"\n\n[rules]\nprefer_const = \"warn\"";
+        let over = toml::from_str::<toml::Value>(text).unwrap();
+        let cfg = LintConfig::discover(dir.path(), Some(&over)).unwrap();
+
+        assert_eq!(
+            cfg.level_for("prefer_const", Some(Group::Style), Level::Allow),
+            Level::Warn
+        );
+    }
+
+    /*
+    A worm lint has a name and no kind, so no group reaches it.
+
+    A worm declares its lints under `[lint.rules.<worm>]`, and nothing says
+    which kind of mistake each one catches. A group that guessed would set a
+    level the worm author never asked for.
+    */
+    #[test]
+    fn a_group_does_not_reach_a_worm_lint() {
+        let dir = tempfile::tempdir().unwrap();
+        let over = toml::from_str::<toml::Value>("[groups]\nstyle = \"allow\"").unwrap();
+        let cfg = LintConfig::discover(dir.path(), Some(&over)).unwrap();
+
+        assert_eq!(
+            cfg.level_for("luaux.useless_fragment", None, Level::Warn),
+            Level::Warn
+        );
+    }
+
+    /// Every lint has a group, so `[lint.groups]` reaches all of them.
+    #[test]
+    fn every_lint_belongs_to_a_group() {
+        for group in Group::all() {
+            assert!(
+                crate::lint::registry().iter().any(|l| l.group() == group),
+                "no lint is in the {} group, so the schema offers a dead key",
+                group.name()
+            );
+        }
+    }
+
+    #[test]
+    fn info_is_a_level_the_config_takes() {
+        let dir = tempfile::tempdir().unwrap();
+        let over = toml::from_str::<toml::Value>("[rules]\nshadowing = \"info\"").unwrap();
+        let cfg = LintConfig::discover(dir.path(), Some(&over)).unwrap();
+
+        assert_eq!(
+            cfg.level_for("shadowing", Some(Group::Suspicious), Level::Warn),
+            Level::Info
         );
     }
 }

--- a/crates/larvae/src/lint/lints/conditionals.rs
+++ b/crates/larvae/src/lint/lints/conditionals.rs
@@ -1,0 +1,157 @@
+/*!
+Lints for a conditional that stands where a value belongs.
+
+Luau writes a conditional as a value in two forms: `cond and a or b`, and
+`if cond then a else b`. Both are correct. The complaint is that the decision
+hides inside an expression, where an `if` statement states one case per
+branch.
+
+The two lints report the two forms, and both are off by default. A project
+that wants no conditional value at all turns both on. A project that wants
+one form and not the other turns on the lint for the form it refuses.
+*/
+
+use crate::lint::ctx::{Finding, LintCtx};
+use crate::lints;
+use crate::syntax::ast::*;
+
+use super::correctness::{each_expr, each_stmt, unwrap_parens};
+
+lints! {
+    AndOrConditional => "and_or_conditional", Style, Allow,
+        "cond and a or b used as a value, where an if statement states each case";
+    IfExpressionAssignment => "if_expression_assignment", Style, Allow,
+        "if cond then a else b used as a value, where an if statement states each case";
+}
+
+// --- and_or_conditional ----------------------------------------------------
+
+impl AndOrConditional {
+    /*
+    `local label = ok and "yes" or "no"`.
+
+    The pattern is a conditional built from two operators, and it holds only
+    while the middle value is truthy. With a false or nil middle, the `or`
+    gives the last part for every input. `misleading_and_or` reports that
+    defect where a literal makes it certain. This lint reports the shape
+    itself, for a project that refuses the pattern.
+
+    The lint is off by default, because the pattern is ordinary Lua and it
+    is correct for every truthy middle value.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        each_value(ctx, out, |ctx, e, out| {
+            if !is_and_or(ctx, e) {
+                return;
+            }
+
+            out.push(
+                Finding::new(
+                    "and_or_conditional",
+                    ctx.bytes(e.span()),
+                    "this and-or picks the value with a condition",
+                )
+                .with_help("an if statement gives one branch to each case"),
+            );
+        });
+    }
+}
+
+/// Reports if this expression is `a and b or c`, which Luau groups as
+/// `(a and b) or c`.
+fn is_and_or(ctx: &LintCtx<'_>, e: &Expr) -> bool {
+    let Expr::Binary { op, lhs, .. } = e else {
+        return false;
+    };
+
+    if ctx.text(*op) != "or" {
+        return false;
+    }
+
+    matches!(unwrap_parens(lhs), Expr::Binary { op: and, .. } if ctx.text(*and) == "and")
+}
+
+// --- if_expression_assignment ----------------------------------------------
+
+impl IfExpressionAssignment {
+    /*
+    `local label = if ok then "yes" else "no"`.
+
+    Luau's if expression carries none of the and-or trap, so the complaint
+    here is style alone: the branch lives in the value and not in a
+    statement.
+
+    The lint is off by default, and it has to stay off. `misleading_and_or`
+    names this exact form as the repair, so a default that reports would
+    report the fix that larvae asked for.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        each_value(ctx, out, |ctx, e, out| {
+            if !matches!(e, Expr::IfElse { .. }) {
+                return;
+            }
+
+            out.push(
+                Finding::new(
+                    "if_expression_assignment",
+                    ctx.bytes(e.span()),
+                    "this if expression picks the value with a condition",
+                )
+                .with_help("an if statement gives one branch to each case"),
+            );
+        });
+    }
+}
+
+/*
+Calls `f` on each expression that produces a value for something else.
+
+A conditional in an `if` or `while` condition is what the language asks for
+there, and it says nothing about style. So the walk visits four positions
+only, the ones where an `if` statement writes the same code with one branch
+per case: a local, an assignment, a return, and a call argument.
+
+The walk reads the value and not the parts inside it. `f(c and a or b)` is a
+conditional argument. `x = (c and a or b) + 1` is arithmetic over one, where
+an `if` statement would repeat the addition in both branches.
+*/
+fn each_value(
+    ctx: &LintCtx<'_>,
+    out: &mut Vec<Finding>,
+    mut f: impl FnMut(&LintCtx<'_>, &Expr, &mut Vec<Finding>),
+) {
+    each_stmt(ctx, out, |ctx, s, out| {
+        let values = match s {
+            Stmt::Local(n) => &n.values,
+
+            Stmt::Assign(n) => &n.values,
+
+            Stmt::Return(n) => &n.values,
+
+            _ => return,
+        };
+
+        for value in values {
+            f(ctx, unwrap_parens(value), out);
+        }
+    });
+
+    /*
+    An argument list arrives through the expression walk, because a call is
+    an expression wherever it stands. A `f "str"` or a `f {t}` call carries
+    one literal and can hold no conditional, so those forms need no work.
+    */
+    each_expr(ctx, out, |ctx, e, out| {
+        let Expr::Call {
+            args: CallArgs::Paren(args),
+            ..
+        } = e
+        else {
+            return;
+        };
+
+        for arg in args {
+            f(ctx, unwrap_parens(arg), out);
+        }
+    });
+}

--- a/crates/larvae/src/lint/lints/configured.rs
+++ b/crates/larvae/src/lint/lints/configured.rs
@@ -30,6 +30,8 @@ lints! {
         "calling a pure function and discarding what it returned";
     PreferConst => "prefer_const", Style, Allow,
         "a local that nothing reassigns, which const states outright";
+    RestrictedGlobals => "restricted_globals", Style, Warn,
+        "reading a global the project has ruled out";
     RestrictedModulePaths => "restricted_module_paths", Style, Warn,
         "requiring a module the project has ruled out";
 }
@@ -416,6 +418,70 @@ impl RestrictedModulePaths {
                         "restricted_module_paths",
                         ctx.bytes(*span),
                         format!("{path} is restricted"),
+                    )
+                    .with_help(why.clone()),
+                );
+            }
+        });
+    }
+}
+
+// --- restricted_globals ----------------------------------------------------
+
+/*
+The globals that the project forbids, as `name = "why"`.
+
+The map is the whole table, and not a key inside it, so a project writes
+`[lint.options.restricted_globals]` and then one line per name. The reason is
+required, because the message a reader gets is the reason. A list of bare
+names would report "this is restricted" and leave the reader to guess.
+*/
+#[derive(Deserialize, Default)]
+#[serde(transparent)]
+pub struct RestrictedGlobalsOptions {
+    pub names: std::collections::BTreeMap<String, String>,
+}
+
+impl RestrictedGlobals {
+    /*
+    `loadstring("return 1")`, where the project bans `loadstring`.
+
+    This lint is fully config driven, and it is silent until a project fills
+    the config in. Thus the default level costs a project nothing.
+
+    The use is a global that works and that the project still refuses.
+    `loadstring` compiles at runtime, `getfenv` deoptimises the function
+    that holds it, and a house style bans `print` in shipped code. None of
+    them is wrong in general, so a built-in list does not exist and cannot
+    exist.
+
+    A name only counts when it is the global. A local of the same name
+    belongs to the author, and the project ruled out the global.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        let options: RestrictedGlobalsOptions = ctx.cfg.options_for("restricted_globals");
+
+        if options.names.is_empty() {
+            return;
+        }
+
+        each_expr(ctx, out, |ctx, e, out| {
+            let Expr::Name(span) = e else {
+                return;
+            };
+
+            if !ctx.names.is_global(span.start) {
+                return;
+            }
+
+            let name = ctx.text(*span);
+
+            if let Some(why) = options.names.get(name) {
+                out.push(
+                    Finding::new(
+                        "restricted_globals",
+                        ctx.bytes(*span),
+                        format!("{name} is restricted"),
                     )
                     .with_help(why.clone()),
                 );

--- a/crates/larvae/src/lint/lints/configured.rs
+++ b/crates/larvae/src/lint/lints/configured.rs
@@ -16,21 +16,21 @@ use crate::syntax::ast::*;
 use super::correctness::{each_block, each_expr, each_stmt};
 
 lints! {
-    BadStringEscape => "bad_string_escape", Warn,
+    BadStringEscape => "bad_string_escape", Correctness, Warn,
         "an escape sequence the language does not define";
-    Deprecated => "deprecated", Warn,
+    Deprecated => "deprecated", Style, Warn,
         "a function that still works but has been replaced";
-    HighCyclomaticComplexity => "high_cyclomatic_complexity", Allow,
+    HighCyclomaticComplexity => "high_cyclomatic_complexity", Complexity, Allow,
         "a function with more branches than anyone can hold at once";
-    ManualTableClone => "manual_table_clone", Warn,
+    ManualTableClone => "manual_table_clone", Performance, Warn,
         "a loop that copies a table, which table.clone does in one call";
-    MismatchedArgCount => "mismatched_arg_count", Warn,
+    MismatchedArgCount => "mismatched_arg_count", Correctness, Warn,
         "calling a function in this file with the wrong number of arguments";
-    MustUse => "must_use", Warn,
+    MustUse => "must_use", Correctness, Warn,
         "calling a pure function and discarding what it returned";
-    PreferConst => "prefer_const", Allow,
+    PreferConst => "prefer_const", Style, Allow,
         "a local that nothing reassigns, which const states outright";
-    RestrictedModulePaths => "restricted_module_paths", Warn,
+    RestrictedModulePaths => "restricted_module_paths", Style, Warn,
         "requiring a module the project has ruled out";
 }
 

--- a/crates/larvae/src/lint/lints/correctness.rs
+++ b/crates/larvae/src/lint/lints/correctness.rs
@@ -11,25 +11,25 @@ use crate::lints;
 use crate::syntax::ast::*;
 
 lints! {
-    AlmostSwapped => "almost_swapped", Warn,
+    AlmostSwapped => "almost_swapped", Correctness, Warn,
         "two assignments that look like a swap but overwrite one of the values";
-    CompareNan => "compare_nan", Warn,
+    CompareNan => "compare_nan", Correctness, Warn,
         "comparing against nan, which is never equal to anything including itself";
-    ConstantTableComparison => "constant_table_comparison", Warn,
+    ConstantTableComparison => "constant_table_comparison", Correctness, Warn,
         "comparing against a table literal, which compares identity and is always false";
-    DivideByZero => "divide_by_zero", Warn,
+    DivideByZero => "divide_by_zero", Suspicious, Warn,
         "dividing by a literal zero";
-    DuplicateKeys => "duplicate_keys", Deny,
+    DuplicateKeys => "duplicate_keys", Correctness, Deny,
         "a table key written twice, where only the last one survives";
-    IfsSameCond => "ifs_same_cond", Warn,
+    IfsSameCond => "ifs_same_cond", Correctness, Warn,
         "an elseif repeating a condition already tested, which can never run";
-    IfSameThenElse => "if_same_then_else", Warn,
+    IfSameThenElse => "if_same_then_else", Suspicious, Warn,
         "two branches of the same if with identical bodies";
-    SuspiciousReverseLoop => "suspicious_reverse_loop", Warn,
+    SuspiciousReverseLoop => "suspicious_reverse_loop", Correctness, Warn,
         "a numeric for counting down without a negative step, which never runs";
-    TypeCheckInsideCall => "type_check_inside_call", Warn,
+    TypeCheckInsideCall => "type_check_inside_call", Correctness, Warn,
         "a comparison inside type(), where it belongs outside";
-    UnbalancedAssignments => "unbalanced_assignments", Warn,
+    UnbalancedAssignments => "unbalanced_assignments", Correctness, Warn,
         "more names than values, or more values than names";
 }
 

--- a/crates/larvae/src/lint/lints/luau.rs
+++ b/crates/larvae/src/lint/lints/luau.rs
@@ -26,35 +26,35 @@ use super::configured::global_path;
 use super::correctness::{each_block, each_expr, each_stmt, number, unwrap_parens};
 
 lints! {
-    BadCommentDirective => "bad_comment_directive", Warn,
+    BadCommentDirective => "bad_comment_directive", Correctness, Warn,
         "a --! directive that Luau does not know, or one that comes after the code it should govern";
-    BuiltinGlobalWrite => "builtin_global_write", Warn,
+    BuiltinGlobalWrite => "builtin_global_write", Suspicious, Warn,
         "an assignment over a standard global, which every later script sees";
-    ComparisonPrecedence => "comparison_precedence", Warn,
+    ComparisonPrecedence => "comparison_precedence", Correctness, Warn,
         "not a == b, or a chain like a < b < c, which does not group the way it reads";
-    DuplicateFunction => "duplicate_function", Warn,
+    DuplicateFunction => "duplicate_function", Correctness, Warn,
         "two functions of the same name in one scope, where the first is discarded";
-    DuplicateLocal => "duplicate_local", Deny,
+    DuplicateLocal => "duplicate_local", Correctness, Deny,
         "one local statement or parameter list that declares the same name twice";
-    FormatString => "format_string", Deny,
+    FormatString => "format_string", Correctness, Deny,
         "a format string that string.format or os.date rejects at runtime";
-    ImplicitReturn => "implicit_return", Allow,
+    ImplicitReturn => "implicit_return", Suspicious, Allow,
         "a function that returns a value on one path and falls off the end on another";
-    MisleadingAndOr => "misleading_and_or", Warn,
+    MisleadingAndOr => "misleading_and_or", Correctness, Warn,
         "cond and false or b, which always gives b because the middle is never truthy";
-    NumberLiteralOverflow => "number_literal_overflow", Warn,
+    NumberLiteralOverflow => "number_literal_overflow", Correctness, Warn,
         "a hexadecimal or binary literal wider than 64 bits, which is truncated";
-    PlaceholderRead => "placeholder_read", Warn,
+    PlaceholderRead => "placeholder_read", Suspicious, Warn,
         "reading _, the name that says a value is discarded";
-    TableOperations => "table_operations", Warn,
+    TableOperations => "table_operations", Correctness, Warn,
         "a table.insert or table.remove whose index or argument count is wrong";
-    ImplicitAnyLocal => "implicit_any_local", Warn,
+    ImplicitAnyLocal => "implicit_any_local", Suspicious, Warn,
         "a local declared with no value and no type, so what it holds is decided elsewhere";
-    UninitializedLocal => "uninitialized_local", Warn,
+    UninitializedLocal => "uninitialized_local", Correctness, Warn,
         "a local declared with no value and never assigned, so every read is nil";
-    UnknownType => "unknown_type", Warn,
+    UnknownType => "unknown_type", Correctness, Warn,
         "comparing type(x) against a string that type() never returns";
-    ZeroStepLoop => "zero_step_loop", Deny,
+    ZeroStepLoop => "zero_step_loop", Correctness, Deny,
         "a numeric for whose step is zero, so the counter never moves";
 }
 

--- a/crates/larvae/src/lint/lints/luau.rs
+++ b/crates/larvae/src/lint/lints/luau.rs
@@ -50,6 +50,8 @@ lints! {
         "a table.insert or table.remove whose index or argument count is wrong";
     ImplicitAnyLocal => "implicit_any_local", Suspicious, Warn,
         "a local declared with no value and no type, so what it holds is decided elsewhere";
+    ImplicitAnyParameter => "implicit_any_parameter", Suspicious, Allow,
+        "a parameter with no type, so what it takes is decided by the caller";
     UninitializedLocal => "uninitialized_local", Correctness, Warn,
         "a local declared with no value and never assigned, so every read is nil";
     UnknownType => "unknown_type", Correctness, Warn,
@@ -1298,6 +1300,55 @@ impl ImplicitAnyLocal {
                     .with_help(format!(
                         "write the type, `local {name}: T`, or give it a value"
                     )),
+                );
+            }
+        });
+    }
+}
+
+// --- implicit_any_parameter ------------------------------------------------
+
+impl ImplicitAnyParameter {
+    /*
+    `local function apply(list, transform)`.
+
+    A parameter with no annotation is `any`. What the function takes is then
+    decided by each caller, and a reader of the signature cannot tell what
+    the body expects. This is the defect that `implicit_any_local` names, on
+    the other side of the call: that lint asks what a name holds, and this
+    one asks what a function accepts.
+
+    The lint is off by default. Most Luau carries no annotations, so a warn
+    default would report hundreds of times on the first run, and a report
+    that large teaches users to stop reading the linter. A project that
+    wants annotated signatures asks for them in one line.
+
+    Two names are left out. A name that starts with `_` says that nobody
+    wants the value, which is what `unused_variable` exempts through its
+    `ignore_pattern`. `self` is the receiver of a method, and Luau gives it
+    the type of the table that the method hangs on.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        each_function(ctx, |body| {
+            for param in &body.params {
+                // `...` is not a name, and its annotation is a separate question.
+                if param.is_vararg || param.ty.is_some() {
+                    continue;
+                }
+
+                let name = ctx.tok(param.name.start);
+
+                if name == "self" || name.starts_with('_') {
+                    continue;
+                }
+
+                out.push(
+                    Finding::new(
+                        "implicit_any_parameter",
+                        ctx.bytes(param.name),
+                        format!("{name} has no type, so what it takes is decided by the caller"),
+                    )
+                    .with_help(format!("write the type, `{name}: T`")),
                 );
             }
         });

--- a/crates/larvae/src/lint/lints/luau.rs
+++ b/crates/larvae/src/lint/lints/luau.rs
@@ -663,15 +663,43 @@ fn is_append_index(ctx: &LintCtx<'_>, index: &Expr, table: &Expr) -> bool {
 
 // --- misleading_and_or -----------------------------------------------------
 
+/*
+Reports whether this expression can only be `true` or `false`.
+
+Syntax answers this on its own, which is the whole reason the lint can widen
+without types. A comparison yields a boolean whatever its operands are, and
+`not` yields one as well. `and` and `or` do not: they give back an operand,
+so `a and b` is whatever `b` holds.
+*/
+fn always_boolean(ctx: &LintCtx<'_>, e: &Expr) -> bool {
+    match unwrap_parens(e) {
+        Expr::Binary { op, .. } => matches!(ctx.text(*op), "==" | "~=" | "<" | "<=" | ">" | ">="),
+
+        Expr::Unary { op, .. } => ctx.text(*op) == "not",
+
+        _ => false,
+    }
+}
+
 impl MisleadingAndOr {
     /*
-    `cond and false or other`.
+    `cond and false or other`, and the wider case that hides behind it.
 
     `a and b or c` stands in for a conditional, and it works only while `b`
     is truthy. With `false` or `nil` in the middle, the `and` gives that
     value, the `or` sees it as false, and the whole expression is `c` for
     every input. The author wanted `if cond then false else other`, which
     Luau writes as an expression.
+
+    A middle that is provably a boolean is the same defect with a smaller
+    blast radius, and it is the one that reaches production. `ready and
+    (count == 0) or "pending"` gives "pending" when the count is not zero,
+    which is exactly when the author wanted `false`. Nothing about that
+    needs a type: a comparison yields a boolean because it is a comparison.
+
+    The two cases carry different messages, because the first is wrong for
+    every input and the second is wrong for half of them. A reader who sees
+    "always" for a case that is sometimes right stops trusting the linter.
     */
     fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
         each_expr(ctx, out, |ctx, e, out| {
@@ -696,23 +724,29 @@ impl MisleadingAndOr {
                 return;
             }
 
-            let what = match middle.as_ref() {
-                Expr::False(_) => "false",
+            let message = match unwrap_parens(middle.as_ref()) {
+                Expr::False(_) => {
+                    "the middle of this and-or is false, so the result is always the last part"
+                        .to_string()
+                }
 
-                Expr::Nil(_) => "nil",
+                Expr::Nil(_) => {
+                    "the middle of this and-or is nil, so the result is always the last part"
+                        .to_string()
+                }
+
+                other if always_boolean(ctx, other) => format!(
+                    "the middle of this and-or is the boolean `{}`, so the result is the last part \
+                     whenever that is false",
+                    ctx.text(other.span())
+                ),
 
                 _ => return,
             };
 
             out.push(
-                Finding::new(
-                    "misleading_and_or",
-                    ctx.bytes(*span),
-                    format!(
-                        "the middle of this and-or is {what}, so the result is always the last part"
-                    ),
-                )
-                .with_help("write if cond then a else b, which is an expression in Luau"),
+                Finding::new("misleading_and_or", ctx.bytes(*span), message)
+                    .with_help("write if cond then a else b, which is an expression in Luau"),
             );
         });
     }

--- a/crates/larvae/src/lint/lints/mod.rs
+++ b/crates/larvae/src/lint/lints/mod.rs
@@ -77,6 +77,9 @@ pub static ALL: &[&dyn Lint] = &[
     &original::SelfAssignment,
     &original::StringConcatInLoop,
     &original::ShadowedLoopWork,
+    &original::LengthAsCondition,
+    &original::BuiltinShadowed,
+    &original::IgnoredPcallResult,
     // Style.
     &style::EmptyIf,
     &style::EmptyLoop,

--- a/crates/larvae/src/lint/lints/mod.rs
+++ b/crates/larvae/src/lint/lints/mod.rs
@@ -88,14 +88,20 @@ pub static ALL: &[&dyn Lint] = &[
 /*
 The boilerplate that every lint shares.
 
-Each entry declares the unit type, the name that a user writes, the default
-level, and the one-line explanation. The lint itself is the `check` function,
-which the author writes as normal code. Thus the author writes only the part
-that differs per lint.
+Each entry declares the unit type, the name that a user writes, the group it
+belongs to, the default level, and the one-line explanation. The lint itself
+is the `check` function, which the author writes as normal code. Thus the
+author writes only the part that differs per lint.
+
+The group is what a project sets under `[lint.groups]`, and it is also how
+`--explain` and the docs order the list. The file a lint lives in is a
+separate thing and stays that way: these files split by where a lint came
+from, so `configured.rs` holds a compile error beside an opinion about branch
+counts. That is a useful editing category and a useless configuration one.
 */
 #[macro_export]
 macro_rules! lints {
-    ($($ty:ident => $name:literal, $level:ident, $about:literal;)*) => {
+    ($($ty:ident => $name:literal, $group:ident, $level:ident, $about:literal;)*) => {
         $(
             pub struct $ty;
 
@@ -106,6 +112,10 @@ macro_rules! lints {
 
                 fn default_level(&self) -> $crate::lint::Level {
                     $crate::lint::Level::$level
+                }
+
+                fn group(&self) -> $crate::lint::Group {
+                    $crate::lint::Group::$group
                 }
 
                 fn about(&self) -> &'static str {

--- a/crates/larvae/src/lint/lints/mod.rs
+++ b/crates/larvae/src/lint/lints/mod.rs
@@ -6,12 +6,14 @@ a lint by its name, and the name stays the same in every file. Thus to move a
 lint between these files changes nothing that a project can see.
 */
 
+pub mod conditionals;
 pub mod configured;
 pub mod correctness;
 pub mod luau;
 pub mod names;
 pub mod original;
 pub mod roblox;
+pub mod shape;
 pub mod style;
 
 use super::Lint;
@@ -52,6 +54,7 @@ pub static ALL: &[&dyn Lint] = &[
     &luau::PlaceholderRead,
     &luau::TableOperations,
     &luau::ImplicitAnyLocal,
+    &luau::ImplicitAnyParameter,
     &luau::UninitializedLocal,
     &luau::UnknownType,
     // Names.
@@ -67,6 +70,7 @@ pub static ALL: &[&dyn Lint] = &[
     &configured::HighCyclomaticComplexity,
     &configured::ManualTableClone,
     &configured::PreferConst,
+    &configured::RestrictedGlobals,
     // Roblox data types.
     &roblox::RobloxIncorrectColor3NewBounds,
     &roblox::RobloxSuspiciousUdim2New,
@@ -86,6 +90,12 @@ pub static ALL: &[&dyn Lint] = &[
     &style::MixedTable,
     &style::MultipleStatements,
     &style::ParentheseConditions,
+    &shape::ConstantCondition,
+    &shape::ElseAfterReturn,
+    &shape::CollapsibleIf,
+    &shape::NegatedCondition,
+    &conditionals::AndOrConditional,
+    &conditionals::IfExpressionAssignment,
 ];
 
 /*

--- a/crates/larvae/src/lint/lints/names.rs
+++ b/crates/larvae/src/lint/lints/names.rs
@@ -17,17 +17,17 @@ use crate::syntax::ast::*;
 use super::correctness::each_expr;
 
 lints! {
-    GlobalUsage => "global_usage", Warn,
+    GlobalUsage => "global_usage", Suspicious, Warn,
         "reaching into _G, which is shared with every other script";
-    Shadowing => "shadowing", Warn,
+    Shadowing => "shadowing", Suspicious, Warn,
         "a name that hides another still in scope";
-    UndefinedVariable => "undefined_variable", Deny,
+    UndefinedVariable => "undefined_variable", Correctness, Deny,
         "a name nothing declares, which is nil at runtime";
-    UnscopedVariables => "unscoped_variables", Warn,
+    UnscopedVariables => "unscoped_variables", Suspicious, Warn,
         "an assignment with no local, which creates a global";
-    UnusedFunction => "unused_function", Warn,
+    UnusedFunction => "unused_function", Correctness, Warn,
         "a local function that nothing calls";
-    UnusedVariable => "unused_variable", Warn,
+    UnusedVariable => "unused_variable", Correctness, Warn,
         "a name declared and never read";
 }
 

--- a/crates/larvae/src/lint/lints/original.rs
+++ b/crates/larvae/src/lint/lints/original.rs
@@ -7,7 +7,6 @@ reason to run larvae's linter and not a port of a different linter.
 */
 
 use crate::lint::ctx::{Finding, LintCtx};
-use crate::lint::scope::Origin;
 use crate::lints;
 use crate::syntax::ast::*;
 
@@ -98,39 +97,83 @@ impl BuiltinShadowed {
     stops when `table` is a local, because a local of that name belongs to
     somebody else. That silent stop is the case this lint reports.
 
-    A parameter is not reported. `function f(type)` is a small scope that
-    the author reads in full, and the name of a parameter is part of a
-    signature the caller decided. A `for` variable is left alone for the
-    same reason.
+    Three shapes are left alone, and the first is the one that decides
+    whether the lint is usable at all.
+
+    A declaration whose value reads the global of the same name is left
+    alone, and this is the exemption that decides whether the lint is usable.
+    `local pairs = pairs` caches a global in a local, which Lua code does for
+    speed. `local unpack = unpack or table.unpack` picks the one the host
+    has. Both keep the library reachable under the same name, so nothing is
+    lost and nothing is wrong. On a corpus of 364 files the two idioms were
+    48 of 86 findings, and the defect was none of them.
+
+    A parameter and a loop variable are also left alone. Both name a small
+    scope that the author reads in full, and the name of a parameter belongs
+    to a signature the caller decided.
     */
     fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
-        for binding in &ctx.names.bindings {
-            if !matches!(binding.origin, Origin::Local | Origin::LocalFunction) {
-                continue;
+        each_stmt(ctx, out, |ctx, s, out| match s {
+            Stmt::Local(n) => {
+                for (i, binding) in n.names.iter().enumerate() {
+                    let name = ctx.text(binding.name);
+
+                    if !crate::lint::globals::LUAU.contains(&name) {
+                        continue;
+                    }
+
+                    if n.values
+                        .get(i)
+                        .is_some_and(|v| reads_the_global(ctx, v, name))
+                    {
+                        continue;
+                    }
+
+                    report(ctx, binding.name, name, out);
+                }
             }
 
-            if !crate::lint::globals::LUAU.contains(&binding.name) {
-                continue;
+            Stmt::LocalFunction(n) => {
+                let name = ctx.text(n.name);
+
+                if crate::lint::globals::LUAU.contains(&name) {
+                    report(ctx, n.name, name, out);
+                }
             }
 
-            let span = TokSpan::new(
-                binding.declared_at as usize,
-                binding.declared_at as usize + 1,
-            );
-
-            out.push(
-                Finding::new(
-                    "builtin_shadowed",
-                    ctx.bytes(span),
-                    format!(
-                        "{} is a standard global, and this local hides it",
-                        binding.name
-                    ),
-                )
-                .with_help("rename the local, the library is unreachable below this line"),
-            );
-        }
+            _ => {}
+        });
     }
+}
+
+/*
+Reports whether this value reads the global that the new local is named for.
+
+The test is a token scan and not a walk of the tree, because the idiom takes
+several shapes and every one of them mentions the name: `pairs`, `unpack or
+table.unpack`, `debug and debug.traceback`. A scan reads them all.
+
+`is_global` keeps it honest. It separates a read of the global from a field
+that happens to carry the name, so `local table = other.table` still reports:
+that one hides the library and puts nothing back.
+*/
+fn reads_the_global(ctx: &LintCtx<'_>, value: &Expr, name: &str) -> bool {
+    let span = value.span();
+
+    (span.start..span.end).any(|i| ctx.tok(i) == name && ctx.names.is_global(i))
+}
+
+fn report(ctx: &LintCtx<'_>, span: TokSpan, name: &str, out: &mut Vec<Finding>) {
+    out.push(
+        Finding::new(
+            "builtin_shadowed",
+            ctx.bytes(span),
+            format!("{name} is a standard global, and this local hides it"),
+        )
+        .with_help(format!(
+            "rename the local, or write `local {name} = {name}` to cache the global instead"
+        )),
+    );
 }
 
 // --- ignored_pcall_result --------------------------------------------------

--- a/crates/larvae/src/lint/lints/original.rs
+++ b/crates/larvae/src/lint/lints/original.rs
@@ -7,10 +7,11 @@ reason to run larvae's linter and not a port of a different linter.
 */
 
 use crate::lint::ctx::{Finding, LintCtx};
+use crate::lint::scope::Origin;
 use crate::lints;
 use crate::syntax::ast::*;
 
-use super::correctness::{each_block, each_stmt};
+use super::correctness::{each_block, each_stmt, unwrap_parens};
 
 lints! {
     NonConstRequire => "non_const_require", Style, Allow,
@@ -23,6 +24,168 @@ lints! {
         "building a string by concatenation in a loop, which is quadratic";
     UnreachableCode => "unreachable_code", Correctness, Warn,
         "statements after a return, break or continue, which never run";
+    LengthAsCondition => "length_as_condition", Correctness, Deny,
+        "#t used as a condition, which is a number and so is always true";
+    BuiltinShadowed => "builtin_shadowed", Suspicious, Warn,
+        "a local that takes the name of a standard global, which the rest of the scope loses";
+    IgnoredPcallResult => "ignored_pcall_result", Suspicious, Warn,
+        "a pcall used as a statement, which catches the error and discards it";
+}
+
+// --- length_as_condition ---------------------------------------------------
+
+/// Every condition slot of a statement, which is where a truthiness bug lives
+fn conditions(s: &Stmt) -> Vec<&Expr> {
+    match s {
+        Stmt::If(n) => n.branches.iter().map(|(cond, _)| cond).collect(),
+
+        Stmt::While(n) => vec![&n.cond],
+
+        Stmt::Repeat(n) => vec![&n.cond],
+
+        _ => Vec::new(),
+    }
+}
+
+impl LengthAsCondition {
+    /*
+    `if #players then`, which is true even with no players.
+
+    Only `nil` and `false` are false in Luau, so a number is true and zero
+    is a number. The guard therefore does nothing, and the branch it guards
+    runs every time. The shape arrives from C and from JavaScript, where the
+    same line means what it says.
+
+    The lint denies. No runtime value makes the finding wrong, because `#t`
+    yields a number for every input and never yields `nil` or `false`. Luau's
+    own linter says nothing about it, checked against luau-lsp.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        each_stmt(ctx, out, |ctx, s, out| {
+            for cond in conditions(s) {
+                let Expr::Unary { op, span, .. } = unwrap_parens(cond) else {
+                    continue;
+                };
+
+                if ctx.text(*op) != "#" {
+                    continue;
+                }
+
+                out.push(
+                    Finding::new(
+                        "length_as_condition",
+                        ctx.bytes(*span),
+                        "a length is a number, and every number is true here",
+                    )
+                    .with_help("compare it, as in #t > 0, or test the value itself"),
+                );
+            }
+        });
+    }
+}
+
+// --- builtin_shadowed ------------------------------------------------------
+
+impl BuiltinShadowed {
+    /*
+    `local table = {}`, and `table.insert` is gone for the rest of the scope.
+
+    The name still resolves, so nothing fails where the local is declared.
+    The failure lands later, at the first line that wanted the library, and
+    it reads as a missing function rather than as a name that moved.
+
+    Larvae already reasons about this and says nothing: `table_operations`
+    stops when `table` is a local, because a local of that name belongs to
+    somebody else. That silent stop is the case this lint reports.
+
+    A parameter is not reported. `function f(type)` is a small scope that
+    the author reads in full, and the name of a parameter is part of a
+    signature the caller decided. A `for` variable is left alone for the
+    same reason.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        for binding in &ctx.names.bindings {
+            if !matches!(binding.origin, Origin::Local | Origin::LocalFunction) {
+                continue;
+            }
+
+            if !crate::lint::globals::LUAU.contains(&binding.name) {
+                continue;
+            }
+
+            let span = TokSpan::new(
+                binding.declared_at as usize,
+                binding.declared_at as usize + 1,
+            );
+
+            out.push(
+                Finding::new(
+                    "builtin_shadowed",
+                    ctx.bytes(span),
+                    format!(
+                        "{} is a standard global, and this local hides it",
+                        binding.name
+                    ),
+                )
+                .with_help("rename the local, the library is unreachable below this line"),
+            );
+        }
+    }
+}
+
+// --- ignored_pcall_result --------------------------------------------------
+
+impl IgnoredPcallResult {
+    /*
+    `pcall(risky)` on a line of its own, which turns error handling off.
+
+    `pcall` returns the success flag first. A call that keeps no result
+    catches the error and drops it, so the failure leaves no trace at all:
+    no crash, no log, and a later line that reads a value nobody wrote.
+    That is worse than the unguarded call, which at least says what broke.
+
+    Only a call as a statement counts. `local ok = pcall(f)` reads the flag,
+    which is the whole point of the function, and every other use keeps the
+    value somewhere.
+
+    The callee must be the global. A project that binds its own `pcall`
+    decided what that name does, and the rule `table_operations` follows is
+    the rule here.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        each_stmt(ctx, out, |ctx, s, out| {
+            let Stmt::Call(call, span) = s else {
+                return;
+            };
+
+            let Expr::Call { func, method, .. } = call else {
+                return;
+            };
+
+            if method.is_some() {
+                return;
+            }
+
+            let Expr::Name(name) = func.as_ref() else {
+                return;
+            };
+
+            let text = ctx.text(*name);
+
+            if !matches!(text, "pcall" | "xpcall") || !ctx.names.is_global(name.start) {
+                return;
+            }
+
+            out.push(
+                Finding::new(
+                    "ignored_pcall_result",
+                    ctx.bytes(*span),
+                    format!("this {text} throws its result away, error and all"),
+                )
+                .with_help("keep the flag, as in local ok, err = ..., and act on it"),
+            );
+        });
+    }
 }
 
 // --- non_const_require -----------------------------------------------------

--- a/crates/larvae/src/lint/lints/original.rs
+++ b/crates/larvae/src/lint/lints/original.rs
@@ -13,15 +13,15 @@ use crate::syntax::ast::*;
 use super::correctness::{each_block, each_stmt};
 
 lints! {
-    NonConstRequire => "non_const_require", Allow,
+    NonConstRequire => "non_const_require", Style, Allow,
         "a required module bound with local, where const says it never changes";
-    SelfAssignment => "self_assignment", Warn,
+    SelfAssignment => "self_assignment", Suspicious, Warn,
         "assigning a value to itself, which does nothing";
-    ShadowedLoopWork => "loop_invariant_call", Warn,
+    ShadowedLoopWork => "loop_invariant_call", Performance, Warn,
         "a call inside a loop whose result cannot change between iterations";
-    StringConcatInLoop => "string_concat_in_loop", Warn,
+    StringConcatInLoop => "string_concat_in_loop", Performance, Warn,
         "building a string by concatenation in a loop, which is quadratic";
-    UnreachableCode => "unreachable_code", Warn,
+    UnreachableCode => "unreachable_code", Correctness, Warn,
         "statements after a return, break or continue, which never run";
 }
 

--- a/crates/larvae/src/lint/lints/roblox.rs
+++ b/crates/larvae/src/lint/lints/roblox.rs
@@ -20,11 +20,11 @@ use crate::syntax::ast::*;
 use super::correctness::each_expr;
 
 lints! {
-    RobloxIncorrectColor3NewBounds => "roblox_incorrect_color3_new_bounds", Warn,
+    RobloxIncorrectColor3NewBounds => "roblox_incorrect_color3_new_bounds", Roblox, Warn,
         "Color3.new given a channel over 1, where the scale is 0 to 1";
-    RobloxManualFromScaleOrOffset => "roblox_manual_fromscale_or_fromoffset", Warn,
+    RobloxManualFromScaleOrOffset => "roblox_manual_fromscale_or_fromoffset", Roblox, Warn,
         "a UDim2.new that fromScale or fromOffset says more clearly";
-    RobloxSuspiciousUdim2New => "roblox_suspicious_udim2_new", Warn,
+    RobloxSuspiciousUdim2New => "roblox_suspicious_udim2_new", Roblox, Warn,
         "UDim2.new given two arguments, where it takes four";
 }
 

--- a/crates/larvae/src/lint/lints/shape.rs
+++ b/crates/larvae/src/lint/lints/shape.rs
@@ -1,0 +1,255 @@
+/*!
+Lints for the shape of a branch, and not for what the branch computes.
+
+Each lint here reads the code twice: once as the author wrote it, and once in
+the form that says the same thing with less structure. The finding is the
+difference between the two. Biome reports each of these shapes in JavaScript,
+and Luau code grows them for the same reasons.
+*/
+
+use crate::lint::ctx::{Finding, LintCtx};
+use crate::lints;
+use crate::syntax::ast::*;
+
+use super::correctness::{each_stmt, unwrap_parens};
+
+lints! {
+    ConstantCondition => "constant_condition", Correctness, Warn,
+        "a condition that is a literal, so the branch is decided already";
+    ElseAfterReturn => "else_after_return", Style, Allow,
+        "an else after a branch that returns, breaks or continues";
+    CollapsibleIf => "collapsible_if", Style, Allow,
+        "an if that holds one if and nothing else";
+    NegatedCondition => "negated_condition", Style, Allow,
+        "an if with a negated condition and an else";
+}
+
+// --- constant_condition ----------------------------------------------------
+
+impl ConstantCondition {
+    /*
+    `if true then`, `if nil then`, `if 0 then`, `if "cache" then`.
+
+    A literal decides the branch before the program runs. Either a debug
+    edit stayed in, or the author meant to name a value and wrote the value
+    itself. The number case is the one that surprises people: Luau follows
+    Lua, where only `nil` and `false` are false. Thus `if 0 then` runs the
+    branch, and so does `if "" then`.
+
+    Two loops are exempt. `while true do` is how Luau writes a loop that a
+    `break` or a `return` ends, and `repeat ... until false` is that loop
+    with the test at the bottom. Both forms are standard, and a report on
+    them would teach the reader to ignore this lint.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        each_stmt(ctx, out, |ctx, s, out| {
+            let conds: Vec<&Expr> = match s {
+                Stmt::If(n) => n.branches.iter().map(|(c, _)| c).collect(),
+
+                // The exempt loops, which are the two standard forms.
+                Stmt::While(n) if constant_truth(&n.cond) == Some(true) => return,
+
+                Stmt::Repeat(n) if constant_truth(&n.cond) == Some(false) => return,
+
+                Stmt::While(n) => vec![&n.cond],
+
+                Stmt::Repeat(n) => vec![&n.cond],
+
+                _ => return,
+            };
+
+            for cond in conds {
+                let Some(truth) = constant_truth(cond) else {
+                    continue;
+                };
+
+                let (verdict, help) = match truth {
+                    true => (
+                        "always true",
+                        "only nil and false are false in Luau, so 0 and \"\" pass here",
+                    ),
+
+                    false => ("always false", "the code under it never runs"),
+                };
+
+                out.push(
+                    Finding::new(
+                        "constant_condition",
+                        ctx.bytes(cond.span()),
+                        format!("this condition is {verdict}"),
+                    )
+                    .with_help(help),
+                );
+            }
+        });
+    }
+}
+
+// --- else_after_return -----------------------------------------------------
+
+impl ElseAfterReturn {
+    /*
+    `if x then return ... else ... end`.
+
+    The else costs a level of indent and buys nothing, because the branch
+    above it left the block already. The body of the else can sit after the
+    `if`, at the level of the rest of the function.
+
+    Every branch has to end in the jump, and not the first one alone. An
+    `elseif` that falls through still needs the else: to drop it there would
+    run the else body after that branch as well, which changes the program.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        each_stmt(ctx, out, |ctx, s, out| {
+            let Stmt::If(n) = s else {
+                return;
+            };
+
+            let Some(block) = &n.else_block else {
+                return;
+            };
+
+            if !n.branches.iter().all(|(_, b)| jumps(b)) {
+                return;
+            }
+
+            out.push(
+                Finding::new(
+                    "else_after_return",
+                    keyword_before(ctx, block),
+                    "this else follows a branch that leaves the block",
+                )
+                .with_help("put its body after the if, which saves a level of indent"),
+            );
+        });
+    }
+}
+
+// --- collapsible_if --------------------------------------------------------
+
+impl CollapsibleIf {
+    /*
+    `if a then if b then ... end end`.
+
+    The two tests are one `and` apart, and the nesting says that they are
+    not. The reader of the outer test has to hold it while they read the
+    inner one, and the body sits two levels deep for no reason.
+
+    The lint reports one shape only: one branch each, no else on either, and
+    nothing beside the inner `if`. With any other content the merge changes
+    what runs, and with an else it changes which test guards which body.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        each_stmt(ctx, out, |ctx, s, out| {
+            let Stmt::If(outer) = s else {
+                return;
+            };
+
+            if !one_plain_branch(outer) {
+                return;
+            }
+
+            let [Stmt::If(inner)] = &outer.branches[0].1.stmts[..] else {
+                return;
+            };
+
+            if !one_plain_branch(inner) {
+                return;
+            }
+
+            out.push(
+                Finding::new(
+                    "collapsible_if",
+                    ctx.bytes(inner.span),
+                    "this if is the only thing inside another if",
+                )
+                .with_help("join the two conditions with and"),
+            );
+        });
+    }
+}
+
+// --- negated_condition -----------------------------------------------------
+
+impl NegatedCondition {
+    /*
+    `if not ready then a() else b() end`.
+
+    The reader meets the negative case first and holds it while they read
+    the positive one. To drop the `not` and swap the two bodies states the
+    same thing in the order that the reader expects.
+
+    One branch only. An `elseif` between the two makes the swap a rewrite of
+    the whole chain, and the result is longer than what it replaces.
+    */
+    fn check(ctx: &LintCtx<'_>, out: &mut Vec<Finding>) {
+        each_stmt(ctx, out, |ctx, s, out| {
+            let Stmt::If(n) = s else {
+                return;
+            };
+
+            if n.branches.len() != 1 || n.else_block.is_none() {
+                return;
+            }
+
+            let cond = &n.branches[0].0;
+
+            if !matches!(unwrap_parens(cond), Expr::Unary { op, .. } if ctx.text(*op) == "not") {
+                return;
+            }
+
+            out.push(
+                Finding::new(
+                    "negated_condition",
+                    ctx.bytes(cond.span()),
+                    "this condition is negated and the if has an else",
+                )
+                .with_help("drop the not and swap the two bodies"),
+            );
+        });
+    }
+}
+
+// --- shared ----------------------------------------------------------------
+
+/// Returns what a literal condition decides. `None` when it is not a literal.
+fn constant_truth(e: &Expr) -> Option<bool> {
+    match unwrap_parens(e) {
+        Expr::Nil(_) | Expr::False(_) => Some(false),
+
+        // A number or a string is true in Luau, and that holds for 0 and "".
+        Expr::True(_) | Expr::Number(_) | Expr::String(_) => Some(true),
+
+        _ => None,
+    }
+}
+
+/// Returns true if the last statement of a block leaves the block.
+fn jumps(block: &Block) -> bool {
+    block
+        .stmts
+        .iter()
+        .rev()
+        .find(|s| !matches!(s, Stmt::Empty(_)))
+        .is_some_and(|s| matches!(s, Stmt::Return(_) | Stmt::Break(_) | Stmt::Continue(_)))
+}
+
+/// Returns true if an if is one test over one body, which a merge can hold.
+fn one_plain_branch(n: &If) -> bool {
+    n.branches.len() == 1 && n.else_block.is_none()
+}
+
+/*
+Returns the byte range of the token that opens a block.
+
+The AST holds no span for the `else` word, and the span of a block starts at
+its first statement. Thus a report on the block points at the body, and the
+word that the lint asks the author to remove stays unmarked.
+*/
+fn keyword_before(ctx: &LintCtx<'_>, block: &Block) -> (u32, u32) {
+    match block.span.start.checked_sub(1) {
+        Some(i) => ctx.bytes(TokSpan::new(i as usize, i as usize + 1)),
+
+        None => ctx.bytes(block.span),
+    }
+}

--- a/crates/larvae/src/lint/lints/style.rs
+++ b/crates/larvae/src/lint/lints/style.rs
@@ -14,15 +14,15 @@ use crate::syntax::ast::*;
 use super::correctness::{each_block, each_expr, each_stmt};
 
 lints! {
-    EmptyIf => "empty_if", Warn,
+    EmptyIf => "empty_if", Suspicious, Warn,
         "an if branch with nothing in it";
-    EmptyLoop => "empty_loop", Warn,
+    EmptyLoop => "empty_loop", Suspicious, Warn,
         "a loop body with nothing in it";
-    MixedTable => "mixed_table", Warn,
+    MixedTable => "mixed_table", Suspicious, Warn,
         "a table with both array entries and named keys";
-    MultipleStatements => "multiple_statements", Allow,
+    MultipleStatements => "multiple_statements", Style, Allow,
         "more than one statement on a line";
-    ParentheseConditions => "parenthese_conditions", Warn,
+    ParentheseConditions => "parenthese_conditions", Style, Warn,
         "parentheses around a condition, which Luau does not need";
 }
 

--- a/crates/larvae/src/lint/mod.rs
+++ b/crates/larvae/src/lint/mod.rs
@@ -24,7 +24,7 @@ use anyhow::Result;
 use crate::diag::{Diag, Severity};
 use crate::syntax::{lexer, parser};
 
-pub use config::{Level, LintConfig};
+pub use config::{Group, Level, LintConfig};
 pub use ctx::{Finding, LintCtx};
 
 /// One thing that can be wrong with a file.
@@ -34,6 +34,9 @@ pub trait Lint: Sync {
 
     /// Tells if the lint is on by default, and at which level.
     fn default_level(&self) -> Level;
+
+    /// The kind of mistake it catches. `[lint.groups]` sets a level for all of one kind.
+    fn group(&self) -> Group;
 
     /// One line of description. `larvae lint --explain` shows it.
     fn about(&self) -> &'static str;
@@ -79,7 +82,7 @@ pub fn analyze(src: &str, cfg: &LintConfig) -> Result<Vec<Finding>, ParseFailure
     let mut findings = Vec::new();
 
     for lint in registry() {
-        let level = cfg.level_for(lint.name(), lint.default_level());
+        let level = cfg.level_for(lint.name(), Some(lint.group()), lint.default_level());
 
         if level == Level::Allow {
             continue;
@@ -190,7 +193,8 @@ fn worm_findings(
         let name = qualified(worm, &finding.lint);
 
         // The worm states what it found. The config states the level.
-        let level = cfg.level_for(&name, decl.default);
+        // A worm declares a name and not a kind, so no group covers it.
+        let level = cfg.level_for(&name, None, decl.default);
 
         if level == Level::Allow {
             continue;
@@ -466,6 +470,8 @@ impl Finding {
     fn into_diag(self, path: &Path, src: &str, index: &crate::diag::LineIndex) -> Diag {
         let severity = match self.level {
             Level::Deny => Severity::Error,
+
+            Level::Info => Severity::Info,
 
             _ => Severity::Warning,
         };

--- a/crates/larvae/src/lsp/diagnostics.rs
+++ b/crates/larvae/src/lsp/diagnostics.rs
@@ -143,8 +143,10 @@ fn diagnostic(src: &str, lines: &rpc::Lines, finding: Finding) -> Value {
 
 fn severity_of(level: Level) -> u8 {
     match level {
-        // 1 is Error, 2 is Warning, and Allow never reaches here
+        // 1 is Error, 2 is Warning, 3 is Information, and Allow never reaches here
         Level::Deny => 1,
+
+        Level::Info => 3,
 
         _ => 2,
     }

--- a/crates/larvae/src/requires/analyse.rs
+++ b/crates/larvae/src/requires/analyse.rs
@@ -96,6 +96,8 @@ fn severity(level: Level) -> Option<Severity> {
     match level {
         Level::Allow => None,
 
+        Level::Info => Some(Severity::Info),
+
         Level::Warn => Some(Severity::Warning),
 
         Level::Deny => Some(Severity::Error),

--- a/crates/larvae/tests/lint.rs
+++ b/crates/larvae/tests/lint.rs
@@ -2395,6 +2395,49 @@ fn a_parameter_named_for_a_global_is_left_alone() {
 }
 
 /*
+Caching a global in a local of the same name loses nothing.
+
+`local pairs = pairs` is what Lua code does for speed, and `local unpack =
+unpack or table.unpack` picks the one the host has. Both keep the library
+reachable under the same name. On a corpus of 364 files the two idioms were
+48 of 86 findings and the defect was none of them, so the exemption is what
+makes the lint usable rather than noise.
+*/
+#[test]
+fn caching_a_global_under_its_own_name_is_left_alone() {
+    assert!(!fires(
+        "builtin_shadowed",
+        "local pairs = pairs\nreturn pairs\n"
+    ));
+    assert!(!fires(
+        "builtin_shadowed",
+        "local unpack = unpack or table.unpack\nreturn unpack\n"
+    ));
+    assert!(!fires(
+        "builtin_shadowed",
+        "local type, tonumber = type, tonumber\nreturn type, tonumber\n"
+    ));
+}
+
+/*
+A rebind that puts nothing back still reports.
+
+`local table = other.table` hides the library and does not read the global,
+so the name is gone below that line. The token scan asks `is_global`, which
+separates a read of the global from a field that carries the name.
+*/
+#[test]
+fn a_rebind_that_does_not_read_the_global_is_reported() {
+    assert!(fires(
+        "builtin_shadowed",
+        "local table = other.table\nreturn table\n"
+    ));
+
+    // A declaration with no value cannot be caching anything.
+    assert!(fires("builtin_shadowed", "local debug\nreturn debug\n"));
+}
+
+/*
 `pcall(f)` as a statement catches the error and drops it.
 
 The failure then leaves no trace: no crash, no log, and a later line reading

--- a/crates/larvae/tests/lint.rs
+++ b/crates/larvae/tests/lint.rs
@@ -2539,3 +2539,372 @@ fn the_boolean_case_says_whenever_and_not_always() {
     assert!(one.message.contains("whenever"), "{}", one.message);
     assert!(!one.message.contains("always"), "{}", one.message);
 }
+
+// --- and_or_conditional ----------------------------------------------------
+
+#[test]
+fn an_and_or_that_gives_a_value_is_reported() {
+    let cfg = with("and_or_conditional", Level::Warn);
+
+    let cases = [
+        "local ok = true\nlocal a = ok and 1 or 2\nreturn a\n",
+        "local ok, a = true, 0\na = ok and 1 or 2\nreturn a\n",
+        "local ok = true\nreturn ok and 1 or 2\n",
+        "local ok = true\nprint(ok and 1 or 2)\n",
+    ];
+
+    for src in cases {
+        assert!(
+            fired(src, &cfg).contains(&"and_or_conditional".to_string()),
+            "no report for {src}"
+        );
+    }
+}
+
+/// A condition is where the language asks for the operators, and the `if`
+/// statement that reads it is already there.
+#[test]
+fn an_and_or_in_a_condition_is_not_a_value() {
+    let cfg = with("and_or_conditional", Level::Warn);
+
+    let cases = [
+        "local ok, ready = true, false\nif ok and ready or true then print(1) end\n",
+        "local ok, ready = true, false\nwhile ok and ready or true do break end\n",
+        "local ok, ready = true, false\nrepeat print(1) until ok and ready or true\n",
+        // arithmetic over one, where an if statement repeats the addition
+        "local ok = true\nlocal n = 1 + (ok and 2 or 3)\nreturn n\n",
+    ];
+
+    for src in cases {
+        assert!(
+            !fired(src, &cfg).contains(&"and_or_conditional".to_string()),
+            "reported {src}"
+        );
+    }
+}
+
+// --- if_expression_assignment ----------------------------------------------
+
+#[test]
+fn an_if_expression_that_gives_a_value_is_reported() {
+    let cfg = with("if_expression_assignment", Level::Warn);
+
+    let cases = [
+        "local ok = true\nlocal a = if ok then 1 else 2\nreturn a\n",
+        "local ok, a = true, 0\na = if ok then 1 else 2\nreturn a\n",
+        "local ok = true\nreturn if ok then 1 else 2\n",
+        "local ok = true\nprint(if ok then 1 else 2)\n",
+    ];
+
+    for src in cases {
+        assert!(
+            fired(src, &cfg).contains(&"if_expression_assignment".to_string()),
+            "no report for {src}"
+        );
+    }
+}
+
+#[test]
+fn an_if_expression_in_a_condition_is_not_a_value() {
+    let cfg = with("if_expression_assignment", Level::Warn);
+
+    let cases = [
+        "local ok = true\nif (if ok then true else false) then print(1) end\n",
+        "local ok = true\nwhile (if ok then true else false) do break end\n",
+    ];
+
+    for src in cases {
+        assert!(
+            !fired(src, &cfg).contains(&"if_expression_assignment".to_string()),
+            "reported {src}"
+        );
+    }
+}
+
+/*
+Both lints are style opinions, and one reports the form that
+`misleading_and_or` advises. A default that spoke would report the repair
+that another lint asked for.
+*/
+#[test]
+fn a_conditional_value_says_nothing_by_default() {
+    let src = "local ok = true\n\
+               local a = ok and 1 or 2\n\
+               local b = if ok then 1 else 2\n\
+               return a, b\n";
+
+    let reported = names(src);
+
+    for name in ["and_or_conditional", "if_expression_assignment"] {
+        assert!(!reported.contains(&name.to_string()), "{name} speaks first");
+    }
+
+    // the exact repair that misleading_and_or names
+    assert!(!fires(
+        "if_expression_assignment",
+        "local ok = true\nreturn if ok then false else 1\n"
+    ));
+}
+
+// --- shape -----------------------------------------------------------------
+
+#[test]
+fn constant_condition_catches_a_literal_test() {
+    assert!(fires("constant_condition", "if true then work() end\n"));
+    assert!(fires("constant_condition", "if nil then work() end\n"));
+    assert!(fires(
+        "constant_condition",
+        "if \"cache\" then work() end\n"
+    ));
+}
+
+/// Only nil and false are false in Luau, so `if 0 then` runs the branch.
+#[test]
+fn zero_is_a_condition_that_always_passes() {
+    assert!(fires("constant_condition", "if 0 then work() end\n"));
+}
+
+/// Both loops are the standard Luau form, so neither one is a finding.
+#[test]
+fn the_two_endless_loops_are_exempt() {
+    assert!(!fires("constant_condition", "while true do work() end\n"));
+    assert!(!fires("constant_condition", "repeat work() until false\n"));
+}
+
+/// The exemption covers the endless form alone, and not every literal.
+#[test]
+fn a_loop_that_the_literal_stops_is_still_reported() {
+    assert!(fires("constant_condition", "while false do work() end\n"));
+    assert!(fires("constant_condition", "repeat work() until true\n"));
+}
+
+#[test]
+fn a_condition_that_reads_a_value_is_left_alone() {
+    assert!(!fires("constant_condition", "if ready then work() end\n"));
+    assert!(!fires(
+        "constant_condition",
+        "while count > 0 do work() end\n"
+    ));
+}
+
+#[test]
+fn else_after_return_needs_the_switch() {
+    let src = "if x then\n\treturn 1\nelse\n\treturn 2\nend\n";
+
+    assert!(!fires("else_after_return", src));
+
+    assert!(
+        fired(src, &with("else_after_return", Level::Warn))
+            .iter()
+            .any(|n| n == "else_after_return")
+    );
+}
+
+/// Every branch has to jump. An elseif that falls through still needs the else.
+#[test]
+fn a_branch_that_falls_through_keeps_its_else() {
+    let cfg = with("else_after_return", Level::Warn);
+    let has = |src: &str| fired(src, &cfg).iter().any(|n| n == "else_after_return");
+
+    assert!(!has(
+        "if x then\n\treturn 1\nelseif y then\n\tlog()\nelse\n\tstop()\nend\n"
+    ));
+    assert!(!has("if x then\n\ta()\nelse\n\tb()\nend\n"));
+}
+
+#[test]
+fn collapsible_if_needs_the_switch() {
+    let src = "if a then\n\tif b then\n\t\twork()\n\tend\nend\n";
+
+    assert!(!fires("collapsible_if", src));
+
+    assert!(
+        fired(src, &with("collapsible_if", Level::Warn))
+            .iter()
+            .any(|n| n == "collapsible_if")
+    );
+}
+
+/// Anything beside the inner if, or an else on either, blocks the merge.
+#[test]
+fn an_if_that_holds_more_than_one_if_stays() {
+    let cfg = with("collapsible_if", Level::Warn);
+    let has = |src: &str| fired(src, &cfg).iter().any(|n| n == "collapsible_if");
+
+    assert!(!has("if a then\n\tif b then work() end\n\tmore()\nend\n"));
+    assert!(!has(
+        "if a then\n\tif b then work() else other() end\nend\n"
+    ));
+    assert!(!has(
+        "if a then\n\tif b then work() end\nelse\n\tother()\nend\n"
+    ));
+}
+
+#[test]
+fn negated_condition_needs_the_switch() {
+    let src = "if not ready then\n\ta()\nelse\n\tb()\nend\n";
+
+    assert!(!fires("negated_condition", src));
+
+    assert!(
+        fired(src, &with("negated_condition", Level::Warn))
+            .iter()
+            .any(|n| n == "negated_condition")
+    );
+}
+
+#[test]
+fn a_negation_that_costs_the_reader_nothing_stays() {
+    let cfg = with("negated_condition", Level::Warn);
+    let has = |src: &str| fired(src, &cfg).iter().any(|n| n == "negated_condition");
+
+    assert!(!has("if not ready then\n\ta()\nend\n"), "no else to swap");
+    assert!(
+        !has("if not ready then\n\ta()\nelseif other then\n\tb()\nelse\n\tc()\nend\n"),
+        "a swap would rewrite the chain"
+    );
+    assert!(!has("if ready then\n\ta()\nelse\n\tb()\nend\n"));
+}
+
+// --- implicit_any_parameter -------------------------------------------------
+
+const UNTYPED_PARAMS: &str = "local function apply(list, transform)\n\
+                              \treturn transform(list)\n\
+                              end\n\
+                              return apply\n";
+
+/*
+The lint is off until a project asks for it.
+
+Most Luau carries no annotations. A warn default would report hundreds of
+times on the first run, and a report that large teaches users to stop reading
+the linter.
+*/
+#[test]
+fn implicit_any_parameter_says_nothing_until_a_project_asks() {
+    assert!(!fires("implicit_any_parameter", UNTYPED_PARAMS));
+}
+
+/// Each parameter answers for itself, so the two untyped ones give two findings.
+#[test]
+fn a_parameter_with_no_type_is_reported_when_the_project_asks() {
+    let found = fired(UNTYPED_PARAMS, &with("implicit_any_parameter", Level::Warn));
+
+    assert_eq!(
+        found
+            .iter()
+            .filter(|n| *n == "implicit_any_parameter")
+            .count(),
+        2,
+        "{found:?}"
+    );
+}
+
+/// The annotation is the whole ask, so an annotated signature is silent.
+#[test]
+fn a_typed_parameter_is_left_alone() {
+    let src = "local function apply(list: { number }, transform: (number) -> number)\n\
+               \treturn transform(list[1])\n\
+               end\n\
+               return apply\n";
+
+    let found = fired(src, &with("implicit_any_parameter", Level::Warn));
+
+    assert!(
+        !found.iter().any(|n| n == "implicit_any_parameter"),
+        "{found:?}"
+    );
+}
+
+/// A name that starts with `_` says that the body never reads the value.
+#[test]
+fn an_underscore_parameter_is_left_alone() {
+    let src = "local function handler(_, _index)\n\treturn 1\nend\nreturn handler\n";
+    let found = fired(src, &with("implicit_any_parameter", Level::Warn));
+
+    assert!(
+        !found.iter().any(|n| n == "implicit_any_parameter"),
+        "{found:?}"
+    );
+}
+
+/// Luau gives `self` the type of the table the method hangs on.
+#[test]
+fn the_self_of_a_method_is_left_alone() {
+    for src in [
+        "local t = {}\nfunction t:method(a: number)\n\treturn a\nend\nreturn t\n",
+        "local t = {}\nfunction t.method(self, a: number)\n\treturn a\nend\nreturn t\n",
+    ] {
+        let found = fired(src, &with("implicit_any_parameter", Level::Warn));
+
+        assert!(
+            !found.iter().any(|n| n == "implicit_any_parameter"),
+            "{found:?}"
+        );
+    }
+}
+
+/// The vararg takes a list and not one value, so its annotation is another question.
+#[test]
+fn a_vararg_is_left_alone() {
+    let src = "local function log(...)\n\treturn select(\"#\", ...)\nend\nreturn log\n";
+    let found = fired(src, &with("implicit_any_parameter", Level::Warn));
+
+    assert!(
+        !found.iter().any(|n| n == "implicit_any_parameter"),
+        "{found:?}"
+    );
+}
+
+// --- restricted_globals -----------------------------------------------------
+
+/// The lint is fully config driven, so the default level costs a project nothing.
+#[test]
+fn restricted_globals_is_quiet_until_a_project_fills_it_in() {
+    assert!(!fires(
+        "restricted_globals",
+        "return loadstring(\"return 1\")\n"
+    ));
+
+    let cfg = opts(
+        "restricted_globals",
+        "loadstring = \"compiles a string at runtime, ship the code instead\"",
+    );
+
+    let found = fired("return loadstring(\"return 1\")\n", &cfg);
+
+    assert!(found.iter().any(|n| n == "restricted_globals"), "{found:?}");
+}
+
+/// A local of the same name belongs to the author, and the project ruled out the global.
+#[test]
+fn a_local_of_the_restricted_name_is_left_alone() {
+    let cfg = opts(
+        "restricted_globals",
+        "loadstring = \"compiles a string at runtime, ship the code instead\"",
+    );
+
+    let src = "local function loadstring(s)\n\treturn s\nend\nreturn loadstring(\"x\")\n";
+    let found = fired(src, &cfg);
+
+    assert!(
+        !found.iter().any(|n| n == "restricted_globals"),
+        "{found:?}"
+    );
+}
+
+/// A name the config does not list is not restricted.
+#[test]
+fn only_the_named_globals_are_restricted() {
+    let cfg = opts(
+        "restricted_globals",
+        "getfenv = \"deoptimises the whole function\"",
+    );
+
+    let found = fired("return loadstring(\"return 1\")\n", &cfg);
+
+    assert!(
+        !found.iter().any(|n| n == "restricted_globals"),
+        "{found:?}"
+    );
+}

--- a/crates/larvae/tests/lint.rs
+++ b/crates/larvae/tests/lint.rs
@@ -2241,6 +2241,7 @@ fn the_lints_that_deny_are_the_ones_that_earn_it() {
             "duplicate_keys",
             "duplicate_local",
             "format_string",
+            "length_as_condition",
             "undefined_variable",
             "zero_step_loop",
         ]
@@ -2256,6 +2257,7 @@ fn each_deny_reaches_the_report_as_an_error() {
         ("format_string", "return string.format(\"%y\", 1)\n"),
         ("undefined_variable", "return nowhere\n"),
         ("zero_step_loop", "for i = 1, 3, 0 do print(i) end\n"),
+        ("length_as_condition", "if #t then print(1) end\n"),
     ];
 
     for (name, src) in cases {
@@ -2284,6 +2286,7 @@ fn no_deny_reports_a_value_it_cannot_see() {
                print(string.format(f, 1))\n\
                for i = 1, 3, step() do print(i) end\n\
                local _, _ = 1, 2\n\
+               if #t > 0 then print(1) end\n\
                return t\n";
 
     let reported = names(src);
@@ -2293,7 +2296,203 @@ fn no_deny_reports_a_value_it_cannot_see() {
         "format_string",
         "zero_step_loop",
         "duplicate_local",
+        "length_as_condition",
     ] {
         assert!(!reported.contains(&name.to_string()), "{name} guessed");
     }
+}
+
+// --- the Biome shaped gaps -------------------------------------------------
+
+/*
+`#t` as a condition is always true, because a number is true in Luau.
+
+Only `nil` and `false` are false, and zero is a number. So the guard does
+nothing and the branch runs every time. Luau's own linter says nothing about
+the shape, checked against luau-lsp.
+*/
+#[test]
+fn a_length_used_as_a_condition_is_reported() {
+    assert!(fires("length_as_condition", "if #t then print(1) end\n"));
+    assert!(fires("length_as_condition", "while #t do break end\n"));
+    assert!(fires("length_as_condition", "repeat break until #t\n"));
+}
+
+/// A comparison is what the author meant, and it must stay quiet.
+#[test]
+fn a_length_that_is_compared_is_left_alone() {
+    assert!(!fires(
+        "length_as_condition",
+        "if #t > 0 then print(1) end\n"
+    ));
+    assert!(!fires(
+        "length_as_condition",
+        "if #t == 0 then print(1) end\n"
+    ));
+
+    // A length outside a condition is an ordinary value.
+    assert!(!fires("length_as_condition", "local n = #t\nreturn n\n"));
+}
+
+/// It denies, because no runtime value makes the finding wrong.
+#[test]
+fn length_as_condition_denies() {
+    let found = lint(
+        Path::new("test.luau"),
+        "if #t then print(1) end\n",
+        &LintConfig::default(),
+    )
+    .expect("parses");
+
+    let one = found
+        .iter()
+        .find(|d| d.message.contains("length_as_condition"))
+        .expect("it fires");
+
+    assert_eq!(one.severity, Severity::Error);
+}
+
+/*
+A local that takes the name of a standard global hides the library.
+
+`table_operations` already stops when `table` is a local, and says so in its
+own comment. This lint is the diagnostic behind that silent stop.
+*/
+#[test]
+fn a_local_that_hides_a_standard_global_is_reported() {
+    assert!(fires(
+        "builtin_shadowed",
+        "local table = {}\nreturn table\n"
+    ));
+    assert!(fires(
+        "builtin_shadowed",
+        "local function type() end\nreturn type\n"
+    ));
+}
+
+/*
+A parameter and a loop variable are left alone.
+
+Both name a small scope that the author reads in full, and the name of a
+parameter belongs to the signature the caller decided.
+*/
+#[test]
+fn a_parameter_named_for_a_global_is_left_alone() {
+    assert!(!fires(
+        "builtin_shadowed",
+        "local function f(type)\n\treturn type\nend\nreturn f\n"
+    ));
+    assert!(!fires(
+        "builtin_shadowed",
+        "for _, next in t do\n\tprint(next)\nend\n"
+    ));
+
+    // An ordinary name is not a global.
+    assert!(!fires(
+        "builtin_shadowed",
+        "local widget = {}\nreturn widget\n"
+    ));
+}
+
+/*
+`pcall(f)` as a statement catches the error and drops it.
+
+The failure then leaves no trace: no crash, no log, and a later line reading
+a value nobody wrote. That is worse than the unguarded call.
+*/
+#[test]
+fn a_pcall_that_keeps_nothing_is_reported() {
+    assert!(fires("ignored_pcall_result", "pcall(risky)\n"));
+    assert!(fires("ignored_pcall_result", "xpcall(risky, handler)\n"));
+}
+
+/// Reading the flag is the whole point of the function, so that stays quiet.
+#[test]
+fn a_pcall_whose_flag_is_read_is_left_alone() {
+    assert!(!fires(
+        "ignored_pcall_result",
+        "local ok = pcall(risky)\nreturn ok\n"
+    ));
+    assert!(!fires(
+        "ignored_pcall_result",
+        "local ok, err = pcall(risky)\nreturn ok, err\n"
+    ));
+
+    // A local of that name belongs to the project, not to the language.
+    assert!(!fires(
+        "ignored_pcall_result",
+        "local function pcall(f)\n\treturn f\nend\npcall(risky)\n"
+    ));
+}
+
+/*
+`misleading_and_or` reaches a middle that syntax proves is a boolean.
+
+`ready and (count == 0) or "pending"` gives "pending" when the count is not
+zero, which is exactly when the author wanted `false`. A comparison yields a
+boolean because it is a comparison, so no type is needed to know it.
+*/
+#[test]
+fn an_and_or_with_a_boolean_middle_is_reported() {
+    assert!(fires(
+        "misleading_and_or",
+        "local x = ready and (count == 0) or \"pending\"\nreturn x\n"
+    ));
+    assert!(fires(
+        "misleading_and_or",
+        "local x = ready and not locked or fallback\nreturn x\n"
+    ));
+
+    // The literal cases still report, and they say "always".
+    let found = lint(
+        Path::new("test.luau"),
+        "local x = ready and false or other\nreturn x\n",
+        &LintConfig::default(),
+    )
+    .expect("parses");
+
+    assert!(
+        found
+            .iter()
+            .any(|d| d.message.contains("misleading_and_or") && d.message.contains("always")),
+        "the literal case lost its message"
+    );
+}
+
+/*
+A middle that is not provably a boolean stays quiet.
+
+`ok and count or 0` is correct whenever `count` is truthy, and larvae cannot
+see the value. To report it would need the type, which the parser does not
+build, so the lint stops where the proof stops.
+*/
+#[test]
+fn an_and_or_with_an_ordinary_middle_is_left_alone() {
+    assert!(!fires(
+        "misleading_and_or",
+        "local x = ok and count or 0\nreturn x\n"
+    ));
+    assert!(!fires(
+        "misleading_and_or",
+        "local x = ok and record.enabled or default\nreturn x\n"
+    ));
+}
+
+/// The wider message names the middle, so a reader sees what larvae proved.
+#[test]
+fn the_boolean_case_says_whenever_and_not_always() {
+    let found = lint(
+        Path::new("test.luau"),
+        "local x = ready and (count == 0) or \"pending\"\nreturn x\n",
+        &LintConfig::default(),
+    )
+    .expect("parses");
+
+    let one = found
+        .iter()
+        .find(|d| d.message.contains("misleading_and_or"))
+        .expect("it fires");
+
+    assert!(one.message.contains("whenever"), "{}", one.message);
+    assert!(!one.message.contains("always"), "{}", one.message);
 }

--- a/larvae.example.toml
+++ b/larvae.example.toml
@@ -212,9 +212,9 @@ exclude = ["Packages", "**/*.spec.luau"] # relative to the project root
 performance = "info"                     # the six kinds: correctness, suspicious,
 complexity = "allow"                     # style, complexity, performance, roblox
 
-# A lint keeps its own default until it is named here. Fifty two of them;
-# `larvae lint --explain <name>` describes one. These are the defaults: five
-# deny, five allow, and the other forty two warn.
+# A lint keeps its own default until it is named here. Sixty three of them;
+# `larvae lint --explain <name>` describes one. These are the defaults: six
+# deny, eleven allow, and the other forty six warn.
 #
 # A lint denies when the code cannot be what the author meant and no reading
 # of it makes the finding wrong. Then the build stops. Everything softer
@@ -229,11 +229,18 @@ duplicate_keys = "deny"                  # the first entry is discarded
 duplicate_local = "deny"                 # the first binding is dead on arrival
 format_string = "deny"                   # string.format raises on this one
 zero_step_loop = "deny"                  # the counter never moves, so it hangs
+length_as_condition = "deny"             # `if #t then` is true with an empty table
 high_cyclomatic_complexity = "allow"     # a branch count is not a defect on its own
 non_const_require = "allow"              # const is newer than most codebases
 prefer_const = "allow"                   # a keyword is a bigger edit than a space
 multiple_statements = "allow"            # `larvae fmt` splits the line already
 implicit_return = "allow"                # a lookup that finds nothing reads well
+implicit_any_parameter = "allow"         # most Luau carries no annotations
+and_or_conditional = "allow"             # `x = c and a or b`, a matter of taste
+if_expression_assignment = "allow"       # the repair misleading_and_or asks for
+else_after_return = "allow"              # one level of indent, no more
+collapsible_if = "allow"                 # two conditions one `and` apart
+negated_condition = "allow"              # `if not x then a else b`
 unused_variable = "warn"
 shadowing = "warn"
 mixed_table = "warn"
@@ -249,6 +256,14 @@ ignore_pattern = "^_"
 
 [lint.options.high_cyclomatic_complexity]
 maximum_complexity = 40                  # selene's number
+
+# Silent until this table names a global. Each line is a name and the reason a
+# reader is shown, so a bare list would report "restricted" and leave them
+# guessing. getfenv and setfenv turn Luau's optimiser off for the function
+# that holds them, which is a cost and not a matter of taste.
+[lint.options.restricted_globals]
+loadstring = "compiles a string at runtime, ship the code instead"
+getfenv = "turns the optimiser off for this function"
 
 [lint.options.deprecated]
 additional = { "myOldHelper" = "myNewHelper" }

--- a/larvae.example.toml
+++ b/larvae.example.toml
@@ -198,6 +198,20 @@ std = "roblox"                           # or "luau", "none", or a selene name l
 globals = ["shared", "_TESTING"]         # names the project defines itself
 exclude = ["Packages", "**/*.spec.luau"] # relative to the project root
 
+# A level for a whole kind of lint. It sits between `recommended` and
+# [lint.rules]: a name below always wins, and a group covers every lint the
+# project did not name. A group does not wake a lint that is `allow` on
+# purpose, so `style = "info"` leaves `prefer_const` off.
+#
+# The table is separate from [lint.rules] on purpose. A table in there is the
+# lints of a worm of that name, and nothing reserves a worm name.
+# A level is allow, info, warn or deny. `info` reports and leaves the exit
+# code alone, exactly as `warn` does; an editor draws it as a hint rather than
+# a squiggle. Only `deny` fails a run.
+[lint.groups]
+performance = "info"                     # the six kinds: correctness, suspicious,
+complexity = "allow"                     # style, complexity, performance, roblox
+
 # A lint keeps its own default until it is named here. Fifty two of them;
 # `larvae lint --explain <name>` describes one. These are the defaults: five
 # deny, five allow, and the other forty two warn.


### PR DESCRIPTION
## What this adds

**`[lint.groups]`** sets a level for a whole kind of lint at once: `correctness`, `suspicious`, `style`, `complexity`, `performance`, `roblox`. Resolution runs most specific first, so a name in `[lint.rules]` beats its group, a group beats `recommended`, and `recommended` beats the lint's default.

Two decisions worth reviewing:

- The table is **separate** from `[lint.rules]`, not nested inside it. A table under `[lint.rules]` already means the lints of a worm of that name, and nothing reserves a worm name, so a worm published as `style` would make `[lint.rules.style]` mean two things at once. Every config written before this reads exactly as it did, and `selene.toml` needs no change.
- A group **does not wake** a lint that is `allow` on purpose. `prefer_const` is off because it rewrites a keyword, and `style = "info"` asks the style lints a project already sees to say less. Naming it in `[lint.rules]` turns it on.

**`info`**, a level below `warn`. Both report and both leave the exit code alone; an editor draws an info as a hint and a warning as a squiggle. The summary counts infos apart, and only when a project uses the level.

**Eleven new lints**, mostly Luau equivalents of Biome rules.

| Lint | Default | What it catches |
| --- | --- | --- |
| `length_as_condition` | deny | `if #t then` is true with an empty table |
| `builtin_shadowed` | warn | `local table = {}` hides the library below it |
| `ignored_pcall_result` | warn | a statement `pcall` discards the error |
| `constant_condition` | warn | `if 0 then` runs, because 0 is truthy in Lua |
| `and_or_conditional` | allow | `cond and a or b` used as a value |
| `if_expression_assignment` | allow | `if cond then a else b` used as a value |
| `else_after_return` | allow | an `else` after a branch that leaves the block |
| `collapsible_if` | allow | two conditions one `and` apart |
| `negated_condition` | allow | `if not x then a else b` |
| `implicit_any_parameter` | allow | a parameter with no type |
| `restricted_globals` | warn | silent until the project names a global |

Luau's own linter reports on none of the first four, checked against `luau-lsp analyze`.

**`misleading_and_or` widens** to a middle that syntax proves is a boolean. `ready and (count == 0) or "pending"` gives `"pending"` when the count is not zero, which is exactly when the author wanted `false`. A comparison yields a boolean because it is a comparison, so no types are needed. The literal case keeps its "always" message; the boolean case says "whenever".

**Default level review.** Five lints deny now rather than one. The bar is two things at once: no reading of the code makes the finding wrong, because each check reads a literal and never a runtime value, and the code as written cannot be what the author meant. `implicit_any_local` steps down from deny to warn, and `implicit_return` and `multiple_statements` step down to allow — `implicit_return` said it was off in its own comment while its level said `warn`, and `multiple_statements` is ground `larvae fmt` already owns.

**Switches.** `[fmt] enabled` and `[lint] enabled` turn one half of larvae off. `[fmt] recommended` gets the same three states `[lint] recommended` has. `larvae init` writes `recommended = true` into both, because a key that is in the file can be turned off and an absent one has to be found in the docs.

## Checked against a corpus

Every default-on lint was run over 364 real Luau and Lua files.

The first cut of `builtin_shadowed` reported **86 times**, and 48 of those were `local pairs = pairs` — the upvalue-caching idiom, which loses nothing. `local unpack = unpack or table.unpack` is the same class. Both are exempt now via a token scan guarded by `is_global`, so `local table = other.table` still reports: that one hides the library and puts nothing back. 37 genuine findings remain.

The rest of the default-on lints find **one** `constant_condition` between them across all 364 files.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets` (silent), `cargo test` (1,499 pass), `cargo build --locked --release`, and `cargo publish --dry-run` for both crates.