### PR TITLE
fix(lsp): register qualified Roblox enum types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes land here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versions follow
 [semver](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Roblox enum names such as `Enum.KeyCode` resolve in type annotations
+
 ## 0.7.3 - 2026-08-30
 
 ### Added

--- a/crates/larvae-lsp/build.rs
+++ b/crates/larvae-lsp/build.rs
@@ -84,6 +84,8 @@ fn build_analyzer() {
     let target = std::env::var("TARGET").unwrap();
     let platform = Platform::of(&target);
 
+    println!("cargo:rerun-if-changed=shim/roblox.cpp");
+    println!("cargo:rerun-if-changed=shim/roblox.h");
     println!("cargo:rerun-if-changed=shim/shim.cpp");
     println!("cargo:rerun-if-changed=shim/shim.h");
     println!("cargo:rerun-if-changed=luau.pin");
@@ -164,6 +166,7 @@ fn build_analyzer() {
         .include(luau.join("Bytecode/include"))
         .include(luau.join("Compiler/include"))
         .include(luau.join("Analysis/include"))
+        .file("shim/roblox.cpp")
         .file("shim/shim.cpp")
         .warnings(false)
         .cargo_metadata(false)

--- a/crates/larvae-lsp/shim/roblox.cpp
+++ b/crates/larvae-lsp/shim/roblox.cpp
@@ -1,0 +1,68 @@
+/*
+The Roblox definitions declare each enum as a flat exported type, ex:
+`EnumKeyCode`, because a definition file cannot declare a type namespace.
+Source code names that type `Enum.KeyCode`. Move the public enum types into
+Luau's imported `Enum` namespace after the definitions load, and keep the
+backing types available only through the values that use them.
+*/
+
+#include "roblox.h"
+
+#include "Luau/Common.h"
+#include "Luau/Frontend.h"
+#include "Luau/Type.h"
+#include "Luau/TypeAttach.h"
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace Larvae
+{
+void registerRobloxEnums(Luau::GlobalTypes& globals)
+{
+    std::unordered_map<Luau::Name, Luau::TypeFun> enumTypes;
+
+    for (auto it = globals.globalScope->exportedTypeBindings.begin();
+         it != globals.globalScope->exportedTypeBindings.end();)
+    {
+        bool erase = false;
+        Luau::TypeId type = it->second.type;
+        auto* external = Luau::getMutable<Luau::ExternType>(type);
+
+        if (external && Luau::startsWith(external->name, "Enum"))
+        {
+            if (external->name != "Enum" && external->name != "Enums" && external->name != "EnumItem")
+            {
+                external->name.erase(0, 4);
+
+                const size_t internal = external->name.rfind("_INTERNAL");
+                if (internal != std::string::npos && internal + 9 == external->name.size())
+                    external->name.erase(internal);
+                else
+                    enumTypes.emplace(external->name, it->second);
+
+                Luau::asMutable(type)->documentationSymbol = "@roblox/enum/" + external->name;
+
+                for (auto& [name, property] : external->props)
+                {
+                    property.documentationSymbol = "@roblox/enum/" + external->name + "." + name;
+                    Luau::attachTag(property, "EnumItem");
+                }
+
+                external->name = "Enum." + external->name;
+                erase = true;
+            }
+
+            external->metatable = std::nullopt;
+        }
+
+        if (erase)
+            it = globals.globalScope->exportedTypeBindings.erase(it);
+        else
+            ++it;
+    }
+
+    globals.globalScope->importedTypeBindings.emplace("Enum", std::move(enumTypes));
+}
+}

--- a/crates/larvae-lsp/shim/roblox.h
+++ b/crates/larvae-lsp/shim/roblox.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace Luau
+{
+struct GlobalTypes;
+}
+
+namespace Larvae
+{
+void registerRobloxEnums(Luau::GlobalTypes& globals);
+}

--- a/crates/larvae-lsp/shim/shim.cpp
+++ b/crates/larvae-lsp/shim/shim.cpp
@@ -12,6 +12,7 @@ session is used from one thread, which the Rust side guarantees.
 */
 
 #include "shim.h"
+#include "roblox.h"
 
 /*
 The layout the Rust side declares, checked where it is defined.
@@ -862,6 +863,9 @@ int larvae_set_definitions(LarvaeSession* s, const char* name, const char* sourc
     Luau::LoadDefinitionFileResult result = s->frontend.loadDefinitionFile(
         s->frontend.globals, s->frontend.globals.globalScope, source, name, false, false);
 
+    if (result.success && strcmp(name, "@roblox") == 0)
+        Larvae::registerRobloxEnums(s->frontend.globals);
+
     attachServiceLookup(s->frontend.globals);
     attachInstanceNew(s->frontend.globals);
 
@@ -884,6 +888,9 @@ int larvae_set_definitions(LarvaeSession* s, const char* name, const char* sourc
                              .loadDefinitionFile(s->frontend.globalsForAutocomplete,
                                  s->frontend.globalsForAutocomplete.globalScope, source, name, false, true)
                              .success;
+
+        if (autocompleteOk && strcmp(name, "@roblox") == 0)
+            Larvae::registerRobloxEnums(s->frontend.globalsForAutocomplete);
 
         attachServiceLookup(s->frontend.globalsForAutocomplete);
         attachInstanceNew(s->frontend.globalsForAutocomplete);

--- a/crates/larvae-lsp/src/analyzer.rs
+++ b/crates/larvae-lsp/src/analyzer.rs
@@ -1261,11 +1261,11 @@ reads as dead everywhere else.
 */
 #[cfg(test)]
 unsafe extern "C" {
-    fn larvae_reset_flags();
+    pub(crate) fn larvae_reset_flags();
 }
 
 #[cfg(test)]
-mod luau_globals {
+pub(crate) mod luau_globals {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Mutex, MutexGuard};
 

--- a/crates/larvae-lsp/src/main.rs
+++ b/crates/larvae-lsp/src/main.rs
@@ -11,6 +11,9 @@ subcommand, which keeps a plain workspace build away from the C++.
 #[cfg(feature = "analyzer")]
 mod analyzer;
 
+#[cfg(all(test, feature = "analyzer"))]
+mod roblox_enum_tests;
+
 // Pure path logic, so it compiles and tests without the vendored C++.
 mod resolve;
 

--- a/crates/larvae-lsp/src/roblox_enum_tests.rs
+++ b/crates/larvae-lsp/src/roblox_enum_tests.rs
@@ -1,0 +1,48 @@
+use std::path::Path;
+
+use larvae::config::lsp::FFlagsConfig;
+use larvae::lsp::analysis::Analysis;
+
+use crate::analyzer::{LuauAnalysis, apply_flags, larvae_reset_flags, luau_globals};
+
+struct Flags(#[allow(dead_code)] luau_globals::Exclusive);
+
+impl Drop for Flags {
+    fn drop(&mut self) {
+        unsafe { larvae_reset_flags() };
+    }
+}
+
+fn enum_complaints() -> Vec<String> {
+    let mut analysis = LuauAnalysis::new();
+    let path = Path::new("/enums.luau");
+
+    analysis.open(
+        path,
+        "--!strict\n\
+         local key: Enum.KeyCode = Enum.KeyCode.A\n\
+         local direction: Enum.EasingDirection = Enum.EasingDirection.In\n\
+         return key, direction\n",
+    );
+
+    analysis
+        .check(path)
+        .into_iter()
+        .map(|diagnostic| diagnostic.message)
+        .collect()
+}
+
+#[test]
+fn roblox_enums_are_qualified_types_under_both_solvers() {
+    let _flags = Flags(luau_globals::exclusive());
+
+    let old_solver = enum_complaints();
+    assert!(old_solver.is_empty(), "old solver: {old_solver:?}");
+
+    let mut flags = FFlagsConfig::default();
+    flags.enable_new_solver = true;
+    apply_flags(&flags);
+
+    let new_solver = enum_complaints();
+    assert!(new_solver.is_empty(), "new solver: {new_solver:?}");
+}


### PR DESCRIPTION
## Summary
- register generated Roblox enum types under the imported `Enum` namespace
- support qualified annotations such as `Enum.KeyCode`
- apply the registration to analysis and old-solver autocomplete globals
- preserve enum documentation symbols, tags, and comparison behavior
- cover qualified enum types under both Luau solvers

## Why
Roblox definition files expose enums as flat generated types such as
`EnumKeyCode` because definition files cannot declare a type namespace.
luau-lsp moves those types into imported `Enum` bindings after loading the
definitions. Without the equivalent mutation, larvae reports valid Roblox
annotations such as `Enum.KeyCode` as unknown types.