### PR TITLE
fix(lsp): resolve aliases in return annotations

### DIFF
--- a/crates/larvae-lsp/shim/shim.cpp
+++ b/crates/larvae-lsp/shim/shim.cpp
@@ -2899,7 +2899,7 @@ A prefixed name, ex: `types.User`, names an imported module and the
 scope holds which one; a bare name is an alias of this file or of a
 scope above the cursor. Both end at a scope that recorded where the
 alias name was written. Definition and type definition ask the same
-question of an annotation, so they share the walk.
+question of an annotation, so they share the lookup.
 */
 static int typeAliasLocation(
     LarvaeSession* s, Luau::Module& module, const char* path, Luau::Position position, LarvaeLocation* out)
@@ -2924,60 +2924,65 @@ static int typeAliasLocation(
             if (alias->nameLocation.containsClosed(position))
                 return fillLocation(s, path, alias->nameLocation, out);
         }
+    }
 
-        auto* reference = up->as<Luau::AstTypeReference>();
+    /*
+    The ancestry walk skips return type packs. Use the type visitor that
+    enters every pack, so an alias in a function return annotation wins
+    before the function type can answer with the function's full span.
+    */
+    TypeAtPosition at(position);
+    source->root->visit(&at);
+    Luau::AstTypeReference* reference = at.found;
 
-        if (!reference)
-            continue;
+    if (!reference)
+        return 0;
 
-        Luau::ScopePtr scope = Luau::findScopeAtPosition(module, position);
+    Luau::ScopePtr scope = Luau::findScopeAtPosition(module, position);
 
-        if (!scope)
-            return 0;
+    if (!scope)
+        return 0;
 
-        const std::string name(reference->name.value);
+    const std::string name(reference->name.value);
 
-        if (reference->prefix)
-        {
-            const std::string prefix(reference->prefix->value);
-
-            for (Luau::ScopePtr at = scope; at; at = at->parent)
-            {
-                auto found = at->importedModules.find(prefix);
-
-                if (found == at->importedModules.end())
-                    continue;
-
-                Luau::ModulePtr imported = s->frontend.moduleResolver.getModule(found->second);
-
-                if (!imported)
-                    return 0;
-
-                Luau::ScopePtr top = imported->getModuleScope();
-
-                if (!top)
-                    return 0;
-
-                auto where = top->typeAliasNameLocations.find(name);
-
-                if (where != top->typeAliasNameLocations.end())
-                    return fillLocation(s, found->second, where->second, out);
-
-                return 0;
-            }
-
-            return 0;
-        }
+    if (reference->prefix)
+    {
+        const std::string prefix(reference->prefix->value);
 
         for (Luau::ScopePtr at = scope; at; at = at->parent)
         {
-            auto where = at->typeAliasNameLocations.find(name);
+            auto found = at->importedModules.find(prefix);
 
-            if (where != at->typeAliasNameLocations.end())
-                return fillLocation(s, path, where->second, out);
+            if (found == at->importedModules.end())
+                continue;
+
+            Luau::ModulePtr imported = s->frontend.moduleResolver.getModule(found->second);
+
+            if (!imported)
+                return 0;
+
+            Luau::ScopePtr top = imported->getModuleScope();
+
+            if (!top)
+                return 0;
+
+            auto where = top->typeAliasNameLocations.find(name);
+
+            if (where != top->typeAliasNameLocations.end())
+                return fillLocation(s, found->second, where->second, out);
+
+            return 0;
         }
 
         return 0;
+    }
+
+    for (Luau::ScopePtr at = scope; at; at = at->parent)
+    {
+        auto where = at->typeAliasNameLocations.find(name);
+
+        if (where != at->typeAliasNameLocations.end())
+            return fillLocation(s, path, where->second, out);
     }
 
     return 0;

--- a/crates/larvae-lsp/src/analyzer.rs
+++ b/crates/larvae-lsp/src/analyzer.rs
@@ -1612,6 +1612,30 @@ mod studio_definitions {
         assert_eq!(from_use.start.0, 3, "line 4 declares it: {from_use:?}");
     }
 
+    /// A function return annotation jumps to the alias name, not the function.
+    #[test]
+    fn a_return_annotation_finds_its_alias() {
+        let _luau = super::luau_globals::shared();
+        let source = "export type Output = () -> Vector3\n\nconst function make(position: Vector3): Output\n\treturn function(): Vector3\n\t\treturn position\n\tend\nend\n";
+        let path = std::path::Path::new("/return-type.luau");
+        let mut analysis = LuauAnalysis::new();
+
+        analysis.definitions("@roblox", GLOBAL_TYPES);
+        analysis.open(path, source);
+
+        let use_at = source.rfind("Output").expect("the return annotation") as u32;
+        let declaration_at = source.find("Output").expect("the exported alias") as u32;
+
+        for at in [use_at, use_at + 1] {
+            let found = analysis
+                .definition(path, at)
+                .expect("the return annotation answers");
+
+            assert_eq!(found.start, (0, declaration_at));
+            assert_eq!(found.end, (0, declaration_at + "Output".len() as u32));
+        }
+    }
+
     /*
     A field of another module jumps to the line that declares it.
 


### PR DESCRIPTION
## Summary
Go to definition on a type alias used as a function return annotation selected the function’s full span instead of the alias declaration.

```luau
export type Output = () -> Vector3

const function make(position: Vector3): Output
    return function(): Vector3
        return position
    end
end
```

Invoking go to definition on the return annotation Output now navigates to the Output binding in the exported type declaration.

## Cause
The AST ancestry walk did not enter function return type packs. Alias lookup therefore missed the type reference and fell through to the function type’s definition location, which covers the function block.

## Change
Use the existing type-position visitor, which enters type packs, when resolving type aliases. Alias declarations still resolve through the existing ancestry lookup.

## Verification
- Added regression coverage for the beginning and interior of the return annotation.
- cargo fmt --all --check
- cargo test --workspace
- cargo test -p larvae-lsp --features analyzer