### PR TITLE
feat(fmt): call_chains opens a chain of calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Notable changes land here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versions follow
 [semver](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `[fmt] call_chains` opens a chain of calls over several lines.
+  `method` keeps the base and its first call together and breaks
+  before each call after it; `full` breaks before every step, so the
+  base stands alone. `preserve` is the default and changes nothing.
+  `min_calls` opens a chain that fits once it holds that many calls,
+  and a chain wider than `column_width` opens whatever it says, which
+  is a case a chain never had: no operator in one breaks, so a long
+  chain ran past the limit
+
 ## 0.7.5 - 2026-08-31
 
 ### Fixed

--- a/crates/larvae/larvae.schema.json
+++ b/crates/larvae/larvae.schema.json
@@ -1283,6 +1283,10 @@
           ],
           "default": "preserve",
           "description": "The keyword a top-level function declaration takes. A dotted or method name has no local form and stays as written, an anonymous function declares nothing, and const applies only where nothing reassigns the name. See https://larvae-luau.github.io/docs/reference/formatting#function-style"
+        },
+        "call_chains": {
+          "$ref": "#/$defs/fmt_call_chains",
+          "description": "How a chain of calls lays out: preserve keeps it on one line, method keeps the base and its first call together, full breaks before every step. See https://larvae-luau.github.io/docs/reference/formatting#call-chains"
         }
       }
     },
@@ -2701,6 +2705,28 @@
         "vector_type": {
           "type": "string",
           "default": "Vector3"
+        }
+      }
+    },
+    "fmt_call_chains": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "style": {
+          "type": "string",
+          "enum": [
+            "preserve",
+            "method",
+            "full"
+          ],
+          "default": "preserve",
+          "description": "How a chain of calls lays out. preserve keeps it on one line, the layout larvae always had. method keeps the base and its first call together and breaks before each call after it. full breaks before every step, so the base stands alone."
+        },
+        "min_calls": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 3,
+          "description": "The number of calls at which a chain opens although it fits. Zero opens only a chain that runs past column_width."
         }
       }
     }

--- a/crates/larvae/src/fmt/config.rs
+++ b/crates/larvae/src/fmt/config.rs
@@ -682,6 +682,79 @@ pub enum FunctionStyle {
     Global,
 }
 
+/*
+How the formatter lays out a chain of calls.
+
+`a.b():c():d()` is one expression that reads as a sequence of steps, and
+a long one runs off the line because no operator in it breaks. These
+values decide where it opens.
+*/
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ChainStyle {
+    /// One line, whatever its width. This is the layout larvae always had.
+    #[default]
+    Preserve,
+    /*
+    A break before each method call, with the base and its first call
+    together:
+
+    ```luau
+    map.new()
+        :some()
+        :other()
+    ```
+    */
+    Method,
+    /*
+    A break before every segment after the base:
+
+    ```luau
+    map
+        .new()
+        :some()
+    ```
+    */
+    Full,
+}
+
+/*
+When a chain of calls opens over several lines.
+
+A chain wider than `column_width` opens whatever `min_calls` says,
+because a line that runs off the screen is the case the option exists
+for. `min_calls` opens a chain that fits as well, because a sequence of
+steps reads as a list once there are enough of them.
+*/
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CallChains {
+    #[serde(default)]
+    pub style: ChainStyle,
+    /*
+    The number of calls at which a chain opens although it fits.
+
+    Three is the first count that reads as a list rather than as one
+    expression, and it is the count the examples above hold. Zero opens
+    only what does not fit.
+    */
+    #[serde(default = "default_min_calls")]
+    pub min_calls: usize,
+}
+
+impl Default for CallChains {
+    fn default() -> Self {
+        Self {
+            style: ChainStyle::default(),
+            min_calls: default_min_calls(),
+        }
+    }
+}
+
+fn default_min_calls() -> usize {
+    3
+}
+
 /// Selects when the formatter opens a union or an intersection over several lines.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -831,6 +904,9 @@ pub struct FmtConfig {
 
     #[serde(default)]
     pub function_style: FunctionStyle,
+
+    #[serde(default)]
+    pub call_chains: CallChains,
 
     /// Selects how a union and an intersection open over several lines.
     #[serde(default)]

--- a/crates/larvae/src/fmt/emit/calls.rs
+++ b/crates/larvae/src/fmt/emit/calls.rs
@@ -7,6 +7,7 @@ meet when the last argument of a call is one.
 */
 
 use super::*;
+use crate::fmt::config::ChainStyle;
 
 impl<'a> Emitter<'a> {
     pub(super) fn call(
@@ -326,4 +327,168 @@ impl<'a> Emitter<'a> {
     table is a list of things and not an expression. Width alone must not
     override that signal.
     */
+}
+
+/// One step of a call chain: `.name(args)` or `:name(args)`
+struct Step<'s> {
+    method: bool,
+    name: TokSpan,
+    type_args: Option<TokSpan>,
+    args: &'s CallArgs,
+    span: TokSpan,
+}
+
+impl<'a> Emitter<'a> {
+    /*
+    A call chain as its base and the steps that follow it.
+
+    `map.new():some()` is a call whose function is a call, so the tree
+    nests to the left and the steps come out in reverse. Only a step
+    that is a call joins the chain: `a.b.c()` has one step, because
+    `a.b` is a name this reads through, not a step of its own.
+
+    A step whose name is computed, ex: `a[k]()`, ends the walk. The
+    chain layout puts a name after a break, and a bracket there reads
+    as an index of the line above it.
+    */
+    fn chain<'s>(&self, expr: &'s Expr) -> Option<(&'s Expr, Vec<Step<'s>>)> {
+        let mut steps = Vec::new();
+        let mut at = expr;
+
+        while let Expr::Call {
+            func,
+            method,
+            type_args,
+            args,
+            span,
+        } = at
+        {
+            match (method, func.as_ref()) {
+                (Some(name), _) => {
+                    steps.push(Step {
+                        method: true,
+                        name: *name,
+                        type_args: *type_args,
+                        args,
+                        span: *span,
+                    });
+
+                    at = func;
+                }
+
+                (
+                    None,
+                    Expr::Index {
+                        object,
+                        key: IndexKey::Field(name),
+                        ..
+                    },
+                ) => {
+                    steps.push(Step {
+                        method: false,
+                        name: *name,
+                        type_args: *type_args,
+                        args,
+                        span: *span,
+                    });
+
+                    at = object;
+                }
+
+                _ => break,
+            }
+        }
+
+        match steps.is_empty() {
+            true => None,
+
+            false => {
+                steps.reverse();
+
+                Some((at, steps))
+            }
+        }
+    }
+
+    /*
+    The chain laid out, or nothing where the option leaves it alone.
+
+    `preserve` answers nothing, and so does a chain with one step: the
+    option is about a sequence, and one call is not one. A chain of
+    `min_calls` steps opens although it fits, because a sequence of
+    steps reads as a list once there are enough of them. Below that
+    count the group decides, so a chain that does not fit still opens.
+    */
+    pub(super) fn call_chain(&self, expr: &Expr) -> Option<Doc<'a>> {
+        let cfg = &self.cfg.call_chains;
+
+        if cfg.style == ChainStyle::Preserve {
+            return None;
+        }
+
+        let (base, steps) = self.chain(expr)?;
+
+        if steps.len() < 2 {
+            return None;
+        }
+
+        let mut head = vec![self.expr(base)];
+        let mut rest = Vec::new();
+
+        for (index, step) in steps.iter().enumerate() {
+            let sep = match step.method {
+                true => ":",
+
+                false => ".",
+            };
+
+            let mut piece = vec![Doc::text(sep), Doc::text(self.one(step.name))];
+
+            if let Some(ty) = step.type_args {
+                piece.push(Doc::text(self.verbatim(ty)));
+            }
+
+            if self.cfg.space_before_call_parens() {
+                piece.push(Doc::text(" "));
+            }
+
+            piece.push(self.call_args(step.args, step.span));
+
+            /*
+            `method` keeps the base and its first step on the first
+            line: `map.new()` and `obj:one()` both read as the thing
+            the rest of the chain acts on. `full` breaks before every
+            step, so the base stands alone.
+            */
+            let attached = cfg.style == ChainStyle::Method && index == 0;
+
+            match attached {
+                true => head.extend(piece),
+
+                false => {
+                    rest.push(Doc::Soft);
+                    rest.extend(piece);
+                }
+            }
+        }
+
+        if rest.is_empty() {
+            return None;
+        }
+
+        let forced = cfg.min_calls > 0 && steps.len() >= cfg.min_calls;
+
+        if forced {
+            for part in &mut rest {
+                if matches!(part, Doc::Soft) {
+                    *part = Doc::Hard;
+                }
+            }
+        }
+
+        Some(Doc::group(Doc::concat([
+            Doc::concat(head),
+            Doc::indent(Doc::concat(rest)),
+        ])))
+    }
 }

--- a/crates/larvae/src/fmt/emit/expr.rs
+++ b/crates/larvae/src/fmt/emit/expr.rs
@@ -114,7 +114,9 @@ impl<'a> Emitter<'a> {
                 type_args,
                 args,
                 span,
-            } => self.call(func, *method, *type_args, args, *span),
+            } => self
+                .call_chain(e)
+                .unwrap_or_else(|| self.call(func, *method, *type_args, args, *span)),
 
             Expr::IfElse {
                 branches,

--- a/crates/larvae/tests/fmt.rs
+++ b/crates/larvae/tests/fmt.rs
@@ -3273,3 +3273,112 @@ fn a_removed_import_leaves_no_blank_line() {
         "local Used = require(\"./a\")\nlocal Other = require(\"./c\")\n\nreturn { Used, Other }\n"
     );
 }
+
+// --- call chains ---------------------------------------------------------
+
+fn chained(style: larvae::fmt::config::ChainStyle, min_calls: usize) -> FmtConfig {
+    FmtConfig {
+        call_chains: larvae::fmt::config::CallChains { style, min_calls },
+        ..Default::default()
+    }
+}
+
+/// The default leaves every chain as the author wrote it.
+#[test]
+fn a_chain_keeps_its_line_by_default() {
+    let src = "local a = map.new():some():other()\nreturn a\n";
+
+    assert_eq!(fmt(src), src);
+}
+
+/// `method` keeps the base and its first call together, and breaks at the calls.
+#[test]
+fn the_method_style_breaks_at_each_call() {
+    use larvae::fmt::config::ChainStyle;
+
+    let out = fmt_with(
+        "local a = map.new():some():some1():some2()\nreturn a\n",
+        chained(ChainStyle::Method, 3),
+    );
+
+    assert_eq!(
+        out,
+        "local a = map.new()\n\t:some()\n\t:some1()\n\t:some2()\nreturn a\n"
+    );
+}
+
+/// `full` breaks before every step, the base alone on its line.
+#[test]
+fn the_full_style_breaks_before_every_step() {
+    use larvae::fmt::config::ChainStyle;
+
+    let out = fmt_with(
+        "local a = map.new():some():some1()\nreturn a\n",
+        chained(ChainStyle::Full, 3),
+    );
+
+    assert_eq!(
+        out,
+        "local a = map\n\t.new()\n\t:some()\n\t:some1()\nreturn a\n"
+    );
+}
+
+/*
+A chain under the threshold stays on its line, and one that does not
+fit opens whatever the threshold says.
+*/
+#[test]
+fn the_threshold_and_the_width_both_open_a_chain() {
+    use larvae::fmt::config::ChainStyle;
+
+    // Two steps, and the threshold asks for three.
+    let short = "local a = obj:one():two()\nreturn a\n";
+    assert_eq!(fmt_with(short, chained(ChainStyle::Method, 3)), short);
+
+    // The same chain opens where the threshold is two.
+    assert_eq!(
+        fmt_with(short, chained(ChainStyle::Method, 2)),
+        "local a = obj:one()\n\t:two()\nreturn a\n"
+    );
+
+    // With no threshold, the width alone decides.
+    let long = "local aRatherLongBindingName = someModule.new():aLongMethodNameHere():anotherLongMethodName():aThirdLongMethodName():plusMore():evenMore()\nreturn aRatherLongBindingName\n";
+    let out = fmt_with(long, chained(ChainStyle::Method, 0));
+
+    assert!(out.contains("\n\t:aLongMethodNameHere()"), "{out}");
+    assert!(
+        out.lines().all(|line| line.len() <= 120),
+        "a line still runs past the width: {out}"
+    );
+}
+
+/// A chain the option opens reads back the same way, so the output is stable.
+#[test]
+fn an_opened_chain_formats_to_itself() {
+    use larvae::fmt::config::ChainStyle;
+
+    let cfg = chained(ChainStyle::Full, 3);
+    let once = fmt_with(
+        "local a = map.new():some():some1()\nreturn a\n",
+        cfg.clone(),
+    );
+
+    assert_eq!(once, fmt_with(&once, cfg), "the second run moved something");
+}
+
+/*
+Only a call joins a chain. `a.b.c` is a name this reads through, and a
+computed step ends the walk, because a bracket after a break reads as
+an index of the line above it.
+*/
+#[test]
+fn a_plain_index_is_not_a_chain() {
+    use larvae::fmt::config::ChainStyle;
+
+    for src in [
+        "local a = one.two.three\nreturn a\n",
+        "local a = obj:only()\nreturn a\n",
+    ] {
+        assert_eq!(fmt_with(src, chained(ChainStyle::Full, 2)), src, "{src}");
+    }
+}

--- a/larvae.example.toml
+++ b/larvae.example.toml
@@ -192,6 +192,12 @@ trailing_comma = true                    # a table that broke keeps its last com
 # only a type reads counts as used.
 unused_imports = "ignore"                # or "underscore", "remove"
 
+# How a chain of calls lays out. "method" keeps the base and its first
+# call together and breaks before each call after it; "full" breaks
+# before every step. min_calls opens a chain that fits once it holds
+# that many calls, and 0 opens only what runs past column_width.
+call_chains = { style = "preserve", min_calls = 3 }
+
 exclude = ["Packages", "**/*.gen.luau"]  # relative to the project root
 # syntax = "Luau"                        # accepted from stylua, and ignored
 


### PR DESCRIPTION
A chain reads as a sequence of steps and no operator in one breaks, so a long chain ran past column_width with nothing larvae could do about it. [fmt] call_chains gives it a layout: method keeps the base and its first call together and breaks before each call after it, full breaks before every step, and preserve is the default, so no project reformats. min_calls opens a chain that fits once it holds that many calls, and a chain wider than the line opens whatever it says.

Only a call joins a chain: a.b.c is a name the walk reads through, and a computed step ends it, because a bracket after a break reads as an index of the line above.