### PR TITLE
fix(lint): preserve worm findings when fallback compilation fails

### DIFF
--- a/crates/larvae/src/lint/mod.rs
+++ b/crates/larvae/src/lint/mod.rs
@@ -370,7 +370,7 @@ pub fn claimed(
     The worm speaks first, and its reply can also carry the Luau shadow. Thus
     a worm that both reports and inherits answers one request and not two.
     */
-    let reply = match spec.lints() {
+    let mut reply = match spec.lints() {
         true => Some(
             pool.lint(index, src)
                 .map_err(|e| Diag::error(path, format!("{e:#}")))?,
@@ -378,33 +378,44 @@ pub fn claimed(
 
         false => None,
     };
+    let reported = reply.as_ref().is_some_and(|r| !r.findings.is_empty());
+    let shadow = reply.as_mut().and_then(|r| r.luau.take());
+    let own = match reply {
+        Some(reply) => worm_findings(path, src, reply, cfg, &spec.manifest.lints, worm)?,
+
+        None => Vec::new(),
+    };
 
     if spec.inherits_lints() {
-        let shadow = reply.as_ref().and_then(|r| r.luau.clone());
-
         /*
-        A worm that sends no shadow still inherits, through the output of its
-        own front-end. That output costs the worm nothing, because the worm
-        already compiles the file for the pipeline.
+        A worm that sends no shadow inherits through its front-end output.
+        When compilation fails, its validated findings remain the report,
+        with their configured levels and suppression.
         */
-        let view = match shadow {
-            Some(text) => Some(text),
+        let projection;
+        let view = match shadow.as_deref() {
+            Some(text) => Some(LuauView::Shadow(text)),
 
-            None => pool
+            None => match pool
                 .compile(index, src)
-                .map_err(|e| Diag::error(path, format!("{e:#}")))?
-                .into_source()
-                .map(Some)
-                .map_err(|e| Diag::error(path, format!("worm `{worm}`, {e:#}")))?,
+                .map_err(|e| Diag::error(path, format!("{e:#}")))
+                .and_then(|output| {
+                    output
+                        .into_source()
+                        .map_err(|e| Diag::error(path, format!("worm `{worm}`, {e:#}")))
+                }) {
+                Ok(text) => {
+                    projection = text;
+                    Some(LuauView::Projection(&projection))
+                }
+
+                Err(_) if reported => None,
+
+                Err(error) => return Err(error),
+            },
         };
 
-        if let Some(text) = view {
-            let view = match reply.as_ref().and_then(|r| r.luau.as_ref()).is_some() {
-                true => LuauView::Shadow(&text),
-
-                false => LuauView::Projection(&text),
-            };
-
+        if let Some(view) = view {
             findings.extend(inherited_findings(
                 path,
                 src,
@@ -425,21 +436,12 @@ pub fn claimed(
     findings rather than misplaced ones.
     */
     if spec.shares()
-        && let Some(shadow) = reply.as_ref().and_then(|r| r.luau.as_ref())
+        && let Some(shadow) = shadow.as_deref()
     {
         findings.extend(foreign(path, shadow, cfg, pool, Some(index))?);
     }
 
-    if let Some(reply) = reply {
-        findings.extend(worm_findings(
-            path,
-            src,
-            reply,
-            cfg,
-            &spec.manifest.lints,
-            worm,
-        )?);
-    }
+    findings.extend(own);
 
     // A stable sort keeps an inherited finding before a worm finding on one byte.
     findings.sort_by_key(|f| f.span.0);

--- a/crates/larvae/src/lsp/tests.rs
+++ b/crates/larvae/src/lsp/tests.rs
@@ -1,6 +1,8 @@
 use super::uri::path_of_uri;
 use super::*;
 
+mod worm_diagnostics;
+
 fn server_with(src: &str) -> Server {
     let mut server = Server::default();
     server.documents.insert("file:///t.luau".into(), src.into());

--- a/crates/larvae/src/lsp/tests/worm_diagnostics.rs
+++ b/crates/larvae/src/lsp/tests/worm_diagnostics.rs
@@ -1,0 +1,221 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use super::*;
+use crate::lint::{self, Level};
+
+const URI: &str = "file:///p/t.luaux";
+const FAIL: &str = "error(\"cannot compile markup\")";
+const FINDING: &str = r#"
+local start = string.find(source, "<Frame")
+if start == nil then
+    error("the fixture has no opening tag")
+end
+return {
+    findings = {{
+        span = {start - 1, start + 5},
+        lint = "parse_error",
+        message = "unclosed element",
+        help = "close the opening tag",
+    }},
+}
+"#;
+
+fn server(src: &str, compile: &str, lint: &str) -> Server {
+    let mut spec = spec(
+        r#"
+name = "markup"
+api = 1
+form = "luau"
+entry = "worm.luau"
+
+[frontend]
+claims = [".luaux"]
+inherit_lints = true
+
+[lints.parse_error]
+default = "deny"
+"#,
+        Path::new("."),
+    );
+    Arc::get_mut(&mut spec).unwrap().artifact = format!(
+        r#"
+type Reply = {{
+    findings: {{{{span: {{number}}, lint: string, message: string, help: string?}}}}?,
+    comments: {{{{number}}}}?,
+    luau: string?,
+}}
+return table.freeze({{
+    frontend = table.freeze({{
+        compile = function(source: string): string?
+            {compile}
+        end,
+        lint = function(source: string): Reply
+            {lint}
+        end,
+    }}),
+}})
+"#
+    )
+    .into_bytes();
+
+    let mut server = Server::default();
+    server.documents.insert(URI.into(), src.into());
+    server.worms = Pool::new(vec![spec], 1);
+    server
+}
+
+#[test]
+fn failed_compilation_preserves_byte_spans_and_terminal_positions() {
+    let src = "-- header\n  <Frame\n";
+    for compile in [FAIL, "return"] {
+        let server = server(src, compile, FINDING);
+        let path = Path::new("t.luaux");
+        let findings = lint::claimed(path, src, &server.lint, &server.worms, 0).unwrap();
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].span, (12, 18));
+        assert_eq!(findings[0].lint, "markup.parse_error");
+        assert_eq!(findings[0].level, Level::Deny);
+        let diags = lint::into_diags(path, src, findings);
+        assert_eq!(diags[0].line_col, Some((2, 3)));
+    }
+}
+
+#[test]
+fn failed_compilation_preserves_the_published_utf16_range() {
+    let src = "-- header\r\n\"😀\" <Frame\r\n";
+    let server = server(src, FAIL, FINDING);
+    let diags = published(&server, URI);
+
+    assert_eq!(
+        diags,
+        json!([{
+            "range": {
+                "start": {"line": 1, "character": 5},
+                "end": {"line": 1, "character": 11},
+            },
+            "severity": 1,
+            "source": "larvae",
+            "code": "markup.parse_error",
+            "message": "unclosed element\nclose the opening tag",
+        }])
+    );
+}
+
+#[test]
+fn failed_compilation_respects_the_configured_level() {
+    let mut server = server("<Frame\n", FAIL, FINDING);
+    server
+        .lint
+        .rules
+        .insert("markup.parse_error".into(), Level::Info);
+    assert_eq!(published(&server, URI)[0]["severity"], 3);
+
+    server
+        .lint
+        .rules
+        .insert("markup.parse_error".into(), Level::Allow);
+    assert_eq!(published(&server, URI), json!([]));
+}
+
+#[test]
+fn failed_compilation_respects_comment_suppressions() {
+    let lint = FINDING.replace(
+        "return {",
+        "return { comments = {{0, string.find(source, \"\\n\") - 1}},",
+    );
+    for comment in [
+        "-- larvae: allow(markup.parse_error)",
+        "-- larvae: lint off",
+    ] {
+        let src = format!("{comment}\n<Frame\n");
+        let server = server(&src, FAIL, &lint);
+        assert_eq!(published(&server, URI), json!([]), "{comment}");
+    }
+}
+
+#[test]
+fn failed_compilation_without_findings_still_reports_the_failure() {
+    for (compile, message) in [
+        (FAIL, "cannot compile markup"),
+        ("return", "returned nothing"),
+    ] {
+        let server = server("<Frame\n", compile, "return {}");
+        let diags = published(&server, URI);
+
+        assert_eq!(diags.as_array().unwrap().len(), 1);
+        assert_eq!(diags[0]["severity"], 1);
+        assert!(
+            diags[0]["message"].as_str().unwrap().contains(message),
+            "{diags}"
+        );
+    }
+}
+
+#[test]
+fn failed_compilation_keeps_lint_reply_validation() {
+    for (lint, message) in [
+        (
+            FINDING.replace("parse_error", "unknown"),
+            "does not declare",
+        ),
+        (FINDING.replace("start + 5", "999"), "off the source"),
+        (
+            FINDING.replace("return {", "return { comments = {{0, 999}},"),
+            "a comment span",
+        ),
+    ] {
+        let src = "<Frame\n";
+        let server = server(src, FAIL, &lint);
+        let error =
+            lint::claimed(Path::new("t.luaux"), src, &server.lint, &server.worms, 0).unwrap_err();
+        assert!(error.message.contains(message), "{}", error.message);
+    }
+}
+
+#[test]
+fn successful_projection_keeps_inherited_findings_first_on_the_same_byte() {
+    let src = "<Frame\n";
+    let server = server(src, "return \"local unused = 1\\n\"", FINDING);
+    let findings =
+        lint::claimed(Path::new("t.luaux"), src, &server.lint, &server.worms, 0).unwrap();
+
+    assert_eq!(findings.len(), 2);
+    assert_eq!(findings[0].lint, "unused_variable");
+    assert_eq!(findings[1].lint, "markup.parse_error");
+    assert_eq!(findings[0].span, (0, 0));
+    assert_eq!(findings[1].span, (0, 6));
+}
+
+#[test]
+fn a_shadow_keeps_exact_inherited_positions_without_compilation() {
+    let src = "local unused = <Frame\n";
+    let lint = FINDING.replace(
+        "return {",
+        "return { luau = string.gsub(source, \"<Frame\", \"nil   \"),",
+    );
+    let server = server(src, FAIL, &lint);
+    let findings =
+        lint::claimed(Path::new("t.luaux"), src, &server.lint, &server.worms, 0).unwrap();
+
+    assert_eq!(findings.len(), 2);
+    assert_eq!(findings[0].lint, "unused_variable");
+    assert_eq!(findings[0].span, (6, 12));
+    assert_eq!(findings[1].span, (15, 21));
+}
+
+#[test]
+fn an_invalid_shadow_still_reports_the_worm_failure() {
+    let src = "<Frame\n";
+    let lint = FINDING.replace("return {", "return { luau = \"local =\",");
+    let server = server(src, FAIL, &lint);
+    let error =
+        lint::claimed(Path::new("t.luaux"), src, &server.lint, &server.worms, 0).unwrap_err();
+
+    assert!(
+        error.message.contains("returned Luau larvae cannot read"),
+        "{}",
+        error.message
+    );
+}


### PR DESCRIPTION
## Summary
When a worm returns positioned findings without a Luau shadow, failed
fallback compilation replaces those findings with an unpositioned error.
The LSP consequently reports the error at line 1.

Validate and preserve the worm's findings when fallback compilation fails.
Retain configured severity, suppression, and original source ranges.
Compilation failures without findings remain errors.

Successful inherited linting and diagnostic ordering remain unchanged.
No formatter, SDK, or dependency changes.

## Verification
- Five regressions failed before the fix; all nine focused tests pass afterward
- Covers byte spans, terminal positions, UTF-16 LSP ranges, suppression, reply validation, and inherited linting
- Larvae package tests passed on Windows
- Library Clippy passed with warnings denied
- Formatting and diff checks passed